### PR TITLE
Updated to event schemas 0.7.4

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -379,7 +379,7 @@ info:
   description: A service managing uploads of file objects to an S3-compatible Object
     Storage.
   title: Upload Controller Service
-  version: 0.3.1
+  version: 0.3.2
 openapi: 3.0.2
 paths:
   /files/{file_id}:

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,8 +36,8 @@ include_package_data = True
 packages = find:
 install_requires =
     ghga-service-chassis-lib[api]==0.16.1
-    ghga-event-schemas==0.6.1
-    hexkit[mongodb,s3,akafka]==0.8.0
+    ghga-event-schemas==0.7.4
+    hexkit[mongodb,s3,akafka]==0.8.1
 
 python_requires = >= 3.9
 

--- a/tests/test_typical_journey.py
+++ b/tests/test_typical_journey.py
@@ -163,7 +163,7 @@ async def test_happy_journey(joint_fixture: JointFixture):  # noqa: F405
     # publish an event to mark the upload as accepted:
     acceptance_event = event_schemas.FileInternallyRegistered(
         file_id=file_to_register.file_id,
-        upload_date=datetime.utcnow(),
+        upload_date=datetime.utcnow().isoformat(),
         decrypted_sha256=file_to_register.decrypted_sha256,
         decrypted_size=file_to_register.decrypted_size,
         decryption_secret_id="some-secret",

--- a/ucs/__init__.py
+++ b/ucs/__init__.py
@@ -15,4 +15,4 @@
 
 """The package implements a service that manages uploads to a S3 inbox bucket."""
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/ucs/adapters/outbound/akafka.py
+++ b/ucs/adapters/outbound/akafka.py
@@ -63,7 +63,8 @@ class EventPubTranslator(EventPublisherPort):
 
         event_payload = event_schemas.FileUploadReceived(
             file_id=file_metadata.file_id,
-            upload_date=upload_date,
+            upload_date=upload_date.isoformat(),
+            submitter_public_key="dummy_pubkey",
             decrypted_size=file_metadata.decrypted_size,
             expected_decrypted_sha256=file_metadata.decrypted_sha256,
         )


### PR DESCRIPTION
Adapting input and models to forward submitter public key is a separate ticket.
For now we just send a dummy.