### PR TITLE
API now expects submitter public key to pass along (GDEV-1502)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -306,6 +306,10 @@ components:
           type: integer
         status:
           $ref: '#/components/schemas/UploadStatus'
+        submitter_public_key:
+          description: The public key used by the submittter to encrypt the file.
+          title: Submitter Public Key
+          type: string
         upload_id:
           title: Upload Id
           type: string
@@ -315,6 +319,7 @@ components:
       - status
       - part_size
       - creation_date
+      - submitter_public_key
       title: Multi-Part Upload Details
       type: object
     UploadAttemptCreation:
@@ -324,8 +329,13 @@ components:
           description: The ID of the file corresponding to this upload.
           title: File Id
           type: string
+        submitter_public_key:
+          description: The public key used by the submittter to encrypt the file.
+          title: Submitter Public Key
+          type: string
       required:
       - file_id
+      - submitter_public_key
       title: Properties required to create a new upload
       type: object
     UploadAttemptUpdate:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -389,7 +389,7 @@ info:
   description: A service managing uploads of file objects to an S3-compatible Object
     Storage.
   title: Upload Controller Service
-  version: 0.3.2
+  version: 0.4.0
 openapi: 3.0.2
 paths:
   /files/{file_id}:

--- a/tests/fixtures/example_data.py
+++ b/tests/fixtures/example_data.py
@@ -54,6 +54,7 @@ EXAMPLE_UPLOAD = models.UploadAttempt(
     status=models.UploadStatus.PENDING,
     part_size=1234,
     creation_date=datetime.now(),
+    submitter_public_key="test-key",
 )
 
 # Multiple example uploads corresponding to EXAMPLE_FILE:

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -52,7 +52,7 @@ async def test_create_upload_not_found(joint_fixture: JointFixture):  # noqa: F4
 
     file_id = "myNonExistingFile001"
     response = await joint_fixture.rest_client.post(
-        "/uploads", json={"file_id": file_id}
+        "/uploads", json={"file_id": file_id, "submitter_public_key": "test-key"}
     )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -85,7 +85,8 @@ async def test_create_upload_other_active(
     await daos.upload_attempts.insert(existing_upload)
 
     response = await joint_fixture.rest_client.post(
-        "/uploads", json={"file_id": EXAMPLE_FILE.file_id}
+        "/uploads",
+        json={"file_id": EXAMPLE_FILE.file_id, "submitter_public_key": "test-key"},
     )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -117,7 +118,8 @@ async def test_create_upload_accepted(
 
     # try to create a new upload:
     response = await joint_fixture.rest_client.post(
-        "/uploads", json={"file_id": EXAMPLE_FILE.file_id}
+        "/uploads",
+        json={"file_id": EXAMPLE_FILE.file_id, "submitter_public_key": "test-key"},
     )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/tests/test_typical_journey.py
+++ b/tests/test_typical_journey.py
@@ -49,7 +49,7 @@ async def perform_upload(
 
     # initiate new upload:
     response = await joint_fixture.rest_client.post(
-        "/uploads", json={"file_id": file_id}
+        "/uploads", json={"file_id": file_id, "submitter_public_key": "test-key"}
     )
     assert response.status_code == status.HTTP_200_OK
     upload_details = response.json()

--- a/ucs/__init__.py
+++ b/ucs/__init__.py
@@ -15,4 +15,4 @@
 
 """The package implements a service that manages uploads to a S3 inbox bucket."""
 
-__version__ = "0.3.2"
+__version__ = "0.4.0"

--- a/ucs/adapters/inbound/fastapi_/rest_models.py
+++ b/ucs/adapters/inbound/fastapi_/rest_models.py
@@ -30,6 +30,9 @@ class UploadAttemptCreation(BaseModel):
     file_id: str = Field(
         ..., description="The ID of the file corresponding to this upload."
     )
+    submitter_public_key: str = Field(
+        ..., description="The public key used by the submittter to encrypt the file."
+    )
 
     class Config:
         """Additional Model Config."""

--- a/ucs/adapters/inbound/fastapi_/routes.py
+++ b/ucs/adapters/inbound/fastapi_/routes.py
@@ -135,7 +135,10 @@ async def create_upload(
     """Initiate a new mutli-part upload for the given file."""
 
     try:
-        return await upload_service.initiate_new(file_id=upload_creation.file_id)
+        return await upload_service.initiate_new(
+            file_id=upload_creation.file_id,
+            submitter_public_key=upload_creation.submitter_public_key,
+        )
     except UploadServicePort.ExistingActiveUploadError as error:
         raise http_exceptions.HttpExistingActiveUploadError(
             file_id=upload_creation.file_id,

--- a/ucs/adapters/outbound/akafka.py
+++ b/ucs/adapters/outbound/akafka.py
@@ -58,13 +58,14 @@ class EventPubTranslator(EventPublisherPort):
         *,
         file_metadata: models.FileMetadata,
         upload_date: datetime,
+        submitter_public_key: str,
     ) -> None:
         """Publish event informing that a new file upload was received."""
 
         event_payload = event_schemas.FileUploadReceived(
             file_id=file_metadata.file_id,
             upload_date=upload_date.isoformat(),
-            submitter_public_key="dummy_pubkey",
+            submitter_public_key=submitter_public_key,
             decrypted_size=file_metadata.decrypted_size,
             expected_decrypted_sha256=file_metadata.decrypted_sha256,
         )

--- a/ucs/core/models.py
+++ b/ucs/core/models.py
@@ -67,6 +67,9 @@ class UploadAttempt(BaseModel):
             + " `None` if the upload is ongoing."
         ),
     )
+    submitter_public_key: str = Field(
+        ..., description="The public key used by the submittter to encrypt the file."
+    )
 
     class Config:
         """Additional Model Config."""

--- a/ucs/ports/inbound/upload_service.py
+++ b/ucs/ports/inbound/upload_service.py
@@ -132,7 +132,9 @@ class UploadServicePort(ABC):
             super().__init__(message)
 
     @abstractmethod
-    async def initiate_new(self, *, file_id: str) -> models.UploadAttempt:
+    async def initiate_new(
+        self, *, file_id: str, submitter_public_key: str
+    ) -> models.UploadAttempt:
         """
         Initiates a new multi-part upload for the file with the given ID.
         """

--- a/ucs/ports/outbound/event_pub.py
+++ b/ucs/ports/outbound/event_pub.py
@@ -29,6 +29,7 @@ class EventPublisherPort(Protocol):
         *,
         file_metadata: models.FileMetadata,
         upload_date: datetime,
+        submitter_public_key: str,
     ) -> None:
         """Publish event informing that a new upload was received."""
         ...


### PR DESCRIPTION
```
Changed /uploads endpoint for POST to expect submitter public key.
Replaced dummy key for outbound Kafka Event.

Co-authored-by: Moritz Hahn <Moritz.Hahn@uni-tuebingen.de>
Co-authored-by: KerstenBreuer <kersten-breuer@outlook.com>
```