### PR TITLE
Dependency quickfix

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -389,7 +389,7 @@ info:
   description: A service managing uploads of file objects to an S3-compatible Object
     Storage.
   title: Upload Controller Service
-  version: 0.4.0
+  version: 0.4.1
 openapi: 3.0.2
 paths:
   /files/{file_id}:

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     ghga-service-chassis-lib[api]==0.16.1
     ghga-event-schemas==0.7.4
     hexkit[mongodb,s3,akafka]==0.8.1
+    typer==0.4.1
 
 python_requires = >= 3.9
 

--- a/ucs/__init__.py
+++ b/ucs/__init__.py
@@ -15,4 +15,4 @@
 
 """The package implements a service that manages uploads to a S3 inbox bucket."""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"


### PR DESCRIPTION
Typer is in chassis-lib[dev], not api, so we need an explicit import for the dockercontainer to work