### PR TITLE
Feature/harmonize events gdev 1558

### DIFF
--- a/.devcontainer/.dev_config.yaml
+++ b/.devcontainer/.dev_config.yaml
@@ -5,7 +5,11 @@ s3_access_key_id: test
 s3_secret_access_key: test
 file_metadata_event_topic: metadata
 file_metadata_event_type: metadata_upsert
-upload_accepted_event_topic: file_ingestion
-upload_accepted_event_type: upload_accepted
+upload_accepted_event_topic: internal_file_registry
+upload_accepted_event_type: file_registered
+upload_received_event_topic: file_uploads
+upload_received_event_type: file_upload_received
+validation_failure_event_topic: file_interrogation
+validation_failure_event_type: file_validation_failure
 service_instance_id: 001
 kafka_servers: ["kafka:9092"]

--- a/.devcontainer/.dev_config.yaml
+++ b/.devcontainer/.dev_config.yaml
@@ -9,7 +9,7 @@ upload_accepted_event_topic: internal_file_registry
 upload_accepted_event_type: file_registered
 upload_received_event_topic: file_uploads
 upload_received_event_type: file_upload_received
-validation_failure_event_topic: file_interrogation
-validation_failure_event_type: file_validation_failure
+upload_rejected_event_topic: file_interrogation
+upload_rejected_event_type: file_validation_failure
 service_instance_id: 001
 kafka_servers: ["kafka:9092"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,7 +31,7 @@
 			88
 		],
 		"licenser.license": "AL2",
-		"licenser.author": "Universität Tübingen, DKFZ and EMBL\nfor the German Human Genome-Phenome Archive (GHGA)",
+		"licenser.author": "Universität Tübingen, DKFZ, EMBL, and Universität zu Köln\nfor the German Human Genome-Phenome Archive (GHGA)",
 		"launch": {
 			"version": "0.2.0",
 			"configurations": [

--- a/.devcontainer/license_header.txt
+++ b/.devcontainer/license_header.txt
@@ -1,4 +1,4 @@
-Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 for the German Human Genome-Phenome Archive (GHGA)
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
-; Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+; Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 ; for the German Human Genome-Phenome Archive (GHGA)
 ;
 ; Licensed under the Apache License, Version 2.0 (the "License");

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+   Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
    for the German Human Genome-Phenome Archive (GHGA)
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/config_schema.json
+++ b/config_schema.json
@@ -6,7 +6,7 @@
     "upload_received_event_topic": {
       "title": "Upload Received Event Topic",
       "description": "Name of the topic to publish event that inform about new file uploads.",
-      "default": "file_uploads",
+      "example": "file_uploads",
       "env_names": [
         "ucs_upload_received_event_topic"
       ],
@@ -15,7 +15,7 @@
     "upload_received_event_type": {
       "title": "Upload Received Event Type",
       "description": "The type to use for event that inform about new file uploads.",
-      "default": "file_upload_received",
+      "example": "file_upload_received",
       "env_names": [
         "ucs_upload_received_event_type"
       ],
@@ -42,7 +42,7 @@
     "upload_accepted_event_topic": {
       "title": "Upload Accepted Event Topic",
       "description": "Name of the topic to receive event that indicate that an upload was by downstream services.",
-      "example": "file_ingestion",
+      "example": "internal_file_registry",
       "env_names": [
         "ucs_upload_accepted_event_topic"
       ],
@@ -51,9 +51,27 @@
     "upload_accepted_event_type": {
       "title": "Upload Accepted Event Type",
       "description": "The type used for event that indicate that an upload was by downstream services.",
-      "example": "file_upload_accepted",
+      "example": "file_registered",
       "env_names": [
         "ucs_upload_accepted_event_type"
+      ],
+      "type": "string"
+    },
+    "validation_failure_event_topic": {
+      "title": "Validation Failure Event Topic",
+      "description": "Name of the topic used for events informing about the outcome of file validations.",
+      "example": "file_interrogation",
+      "env_names": [
+        "ucs_validation_failure_event_topic"
+      ],
+      "type": "string"
+    },
+    "validation_failure_event_type": {
+      "title": "Validation Failure Event Type",
+      "description": "The type used for events informing about the failure of a file validation.",
+      "example": "file_validation_failure",
+      "env_names": [
+        "ucs_validation_failure_event_type"
       ],
       "type": "string"
     },
@@ -301,10 +319,14 @@
     }
   },
   "required": [
+    "upload_received_event_topic",
+    "upload_received_event_type",
     "file_metadata_event_topic",
     "file_metadata_event_type",
     "upload_accepted_event_topic",
     "upload_accepted_event_type",
+    "validation_failure_event_topic",
+    "validation_failure_event_type",
     "service_instance_id",
     "kafka_servers",
     "s3_endpoint_url",

--- a/config_schema.json
+++ b/config_schema.json
@@ -5,7 +5,7 @@
   "properties": {
     "upload_received_event_topic": {
       "title": "Upload Received Event Topic",
-      "description": "Name of the topic to publish event that inform about new file uploads.",
+      "description": "Name of the topic to publish events that inform about new file uploads.",
       "example": "file_uploads",
       "env_names": [
         "ucs_upload_received_event_topic"
@@ -57,21 +57,21 @@
       ],
       "type": "string"
     },
-    "validation_failure_event_topic": {
-      "title": "Validation Failure Event Topic",
-      "description": "Name of the topic used for events informing about the outcome of file validations.",
+    "upload_rejected_event_topic": {
+      "title": "Upload Rejected Event Topic",
+      "description": "Name of the topic used for events informing about rejection of an upload by downstream services due to validation failure.",
       "example": "file_interrogation",
       "env_names": [
-        "ucs_validation_failure_event_topic"
+        "ucs_upload_rejected_event_topic"
       ],
       "type": "string"
     },
-    "validation_failure_event_type": {
-      "title": "Validation Failure Event Type",
+    "upload_rejected_event_type": {
+      "title": "Upload Rejected Event Type",
       "description": "The type used for events informing about the failure of a file validation.",
       "example": "file_validation_failure",
       "env_names": [
-        "ucs_validation_failure_event_type"
+        "ucs_upload_rejected_event_type"
       ],
       "type": "string"
     },
@@ -325,8 +325,8 @@
     "file_metadata_event_type",
     "upload_accepted_event_topic",
     "upload_accepted_event_type",
-    "validation_failure_event_topic",
-    "validation_failure_event_type",
+    "upload_rejected_event_topic",
+    "upload_rejected_event_type",
     "service_instance_id",
     "kafka_servers",
     "s3_endpoint_url",

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -27,6 +27,6 @@ upload_accepted_event_topic: internal_file_registry
 upload_accepted_event_type: file_registered
 upload_received_event_topic: file_uploads
 upload_received_event_type: file_upload_received
-validation_failure_event_topic: file_interrogation
-validation_failure_event_type: file_validation_failure
+upload_rejected_event_topic: file_interrogation
+upload_rejected_event_type: file_validation_failure
 workers: 1

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -23,8 +23,10 @@ s3_secret_access_key: '**********'
 s3_session_token: null
 service_instance_id: '1'
 service_name: upload_controller_service
-upload_accepted_event_topic: file_ingestion
-upload_accepted_event_type: upload_accepted
+upload_accepted_event_topic: internal_file_registry
+upload_accepted_event_type: file_registered
 upload_received_event_topic: file_uploads
 upload_received_event_type: file_upload_received
+validation_failure_event_topic: file_interrogation
+validation_failure_event_type: file_validation_failure
 workers: 1

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -392,7 +392,7 @@ info:
   description: A service managing uploads of file objects to an S3-compatible Object
     Storage.
   title: Upload Controller Service
-  version: 0.4.3
+  version: 0.5.0
 openapi: 3.0.2
 paths:
   /files/{file_id}:

--- a/scripts/get_package_name.py
+++ b/scripts/get_package_name.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/license_checker.py
+++ b/scripts/license_checker.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -107,7 +107,7 @@ limitations under the License."""
 # A list of all chars that may be used to introduce a comment:
 COMMENT_CHARS = ["#"]
 
-AUTHOR = """Universität Tübingen, DKFZ and EMBL
+AUTHOR = """Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 for the German Human Genome-Phenome Archive (GHGA)"""
 
 # The copyright notice should not date earlier than this year:

--- a/scripts/script_utils/__init__.py
+++ b/scripts/script_utils/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/script_utils/cli.py
+++ b/scripts/script_utils/cli.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/script_utils/fastapi_app_location.py
+++ b/scripts/script_utils/fastapi_app_location.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/update_config_docs.py
+++ b/scripts/update_config_docs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/update_openapi_docs.py
+++ b/scripts/update_openapi_docs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/update_template_files.py
+++ b/scripts/update_template_files.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/fixtures/config.py
+++ b/tests/fixtures/config.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/fixtures/example_data.py
+++ b/tests/fixtures/example_data.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/fixtures/joint.py
+++ b/tests/fixtures/joint.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/fixtures/test_config.yaml
+++ b/tests/fixtures/test_config.yaml
@@ -5,7 +5,11 @@ s3_access_key_id: test
 s3_secret_access_key: test
 file_metadata_event_topic: metadata
 file_metadata_event_type: metadata_upsert
-upload_accepted_event_topic: file_ingestion
-upload_accepted_event_type: upload_accepted
+upload_accepted_event_topic: internal_file_registry
+upload_accepted_event_type: file_registered
+upload_received_event_topic: file_uploads
+upload_received_event_type: file_upload_received
+validation_failure_event_topic: file_interrogation
+validation_failure_event_type: file_validation_failure
 service_instance_id: 001
 kafka_servers: ["kafka:9092"]

--- a/tests/fixtures/test_config.yaml
+++ b/tests/fixtures/test_config.yaml
@@ -9,7 +9,7 @@ upload_accepted_event_topic: internal_file_registry
 upload_accepted_event_type: file_registered
 upload_received_event_topic: file_uploads
 upload_received_event_type: file_upload_received
-validation_failure_event_topic: file_interrogation
-validation_failure_event_type: file_validation_failure
+upload_rejected_event_topic: file_interrogation
+upload_rejected_event_type: file_validation_failure
 service_instance_id: 001
 kafka_servers: ["kafka:9092"]

--- a/tests/fixtures/utils.py
+++ b/tests/fixtures/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_typical_journey.py
+++ b/tests/test_typical_journey.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_typical_journey.py
+++ b/tests/test_typical_journey.py
@@ -35,8 +35,8 @@ nest_asyncio.apply()
 
 
 async def run_until_uploaded(joint_fixture: JointFixture):  # noqa: F405
-    """Run steps until uploaded data has been received, the upload attempt marked as
-    uploaded and"""
+    """Run steps until uploaded data has been received and the upload attempt has been
+    marked as uploaded"""
 
     # populate s3 storage:
     await joint_fixture.s3.populate_buckets([joint_fixture.config.inbox_bucket])
@@ -223,8 +223,8 @@ async def test_unhappy_journey(joint_fixture: JointFixture):  # noqa: F405
 
     await joint_fixture.kafka.publish_event(
         payload=json.loads(failure_event.json()),
-        type_=joint_fixture.config.validation_failure_event_type,
-        topic=joint_fixture.config.validation_failure_event_topic,
+        type_=joint_fixture.config.upload_rejected_event_type,
+        topic=joint_fixture.config.upload_rejected_event_topic,
     )
 
     # consume the validation failure event:

--- a/tests/test_typical_journey.py
+++ b/tests/test_typical_journey.py
@@ -34,6 +34,68 @@ from tests.fixtures.joint import *  # noqa: 403
 nest_asyncio.apply()
 
 
+async def run_until_uploaded(joint_fixture: JointFixture):  # noqa: F405
+    """Run steps until uploaded data has been received, the upload attempt marked as
+    uploaded and"""
+
+    # populate s3 storage:
+    await joint_fixture.s3.populate_buckets([joint_fixture.config.inbox_bucket])
+
+    # publish event to register a new file for uplaod:
+    file_to_register = event_schemas.MetadataSubmissionFiles(
+        file_id=EXAMPLE_FILE.file_id,
+        file_name=EXAMPLE_FILE.file_name,
+        decrypted_size=EXAMPLE_FILE.decrypted_size,
+        decrypted_sha256=EXAMPLE_FILE.decrypted_sha256,
+    )
+    file_metadata_event = event_schemas.MetadataSubmissionUpserted(
+        associated_files=[file_to_register]
+    )
+    await joint_fixture.kafka.publish_event(
+        payload=file_metadata_event.dict(),
+        type_=joint_fixture.config.file_metadata_event_type,
+        topic=joint_fixture.config.file_metadata_event_topic,
+    )
+
+    # consume the event:
+    event_subscriber = await joint_fixture.container.kafka_event_subscriber()
+    await event_subscriber.run(forever=False)
+
+    # check that the new file has been registered:
+    response = await joint_fixture.rest_client.get(f"/files/{file_to_register.file_id}")
+    assert response.status_code == status.HTTP_200_OK
+    registered_file = response.json()
+    assert registered_file["file_name"] == file_to_register.file_name
+    assert registered_file["decrypted_sha256"] == file_to_register.decrypted_sha256
+    assert registered_file["decrypted_size"] == file_to_register.decrypted_size
+    assert registered_file["latest_upload_id"] is None
+
+    # perform an upload and cancel it:
+    _ = await perform_upload(
+        joint_fixture, file_id=file_to_register.file_id, final_status="cancelled"
+    )
+
+    # perform another upload and confirm it:
+    async with joint_fixture.kafka.record_events(
+        in_topic=joint_fixture.config.upload_received_event_topic
+    ) as recorder:
+        await perform_upload(
+            joint_fixture, file_id=file_to_register.file_id, final_status="uploaded"
+        )
+
+    # check for the  events:
+    assert len(recorder.recorded_events) == 1
+    assert (
+        recorder.recorded_events[0].type_
+        == joint_fixture.config.upload_received_event_type
+    )
+    payload = event_schemas.FileUploadReceived(**recorder.recorded_events[0].payload)
+    assert payload.file_id == file_to_register.file_id
+    assert payload.expected_decrypted_sha256 == file_to_register.decrypted_sha256
+
+    return file_to_register, event_subscriber
+
+
 async def perform_upload(
     joint_fixture: JointFixture,  # noqa: F405
     *,
@@ -105,60 +167,9 @@ async def perform_upload(
 async def test_happy_journey(joint_fixture: JointFixture):  # noqa: F405
     """Test the typical anticipated/successful journey through the service's APIs."""
 
-    # populate s3 storage:
-    await joint_fixture.s3.populate_buckets([joint_fixture.config.inbox_bucket])
-
-    # publish event to register a new file for uplaod:
-    file_to_register = event_schemas.MetadataSubmissionFiles(
-        file_id=EXAMPLE_FILE.file_id,
-        file_name=EXAMPLE_FILE.file_name,
-        decrypted_size=EXAMPLE_FILE.decrypted_size,
-        decrypted_sha256=EXAMPLE_FILE.decrypted_sha256,
+    file_to_register, event_subscriber = await run_until_uploaded(
+        joint_fixture=joint_fixture
     )
-    file_metadata_event = event_schemas.MetadataSubmissionUpserted(
-        associated_files=[file_to_register]
-    )
-    await joint_fixture.kafka.publish_event(
-        payload=file_metadata_event.dict(),
-        type_=joint_fixture.config.file_metadata_event_type,
-        topic=joint_fixture.config.file_metadata_event_topic,
-    )
-
-    # consume the event:
-    event_subscriber = await joint_fixture.container.kafka_event_subscriber()
-    await event_subscriber.run(forever=False)
-
-    # check that the new file has been registered:
-    response = await joint_fixture.rest_client.get(f"/files/{file_to_register.file_id}")
-    assert response.status_code == status.HTTP_200_OK
-    registered_file = response.json()
-    assert registered_file["file_name"] == file_to_register.file_name
-    assert registered_file["decrypted_sha256"] == file_to_register.decrypted_sha256
-    assert registered_file["decrypted_size"] == file_to_register.decrypted_size
-    assert registered_file["latest_upload_id"] is None
-
-    # perform an upload and cancel it:
-    _ = await perform_upload(
-        joint_fixture, file_id=file_to_register.file_id, final_status="cancelled"
-    )
-
-    # perform another upload and confirm it:
-    async with joint_fixture.kafka.record_events(
-        in_topic=joint_fixture.config.upload_received_event_topic
-    ) as recorder:
-        await perform_upload(
-            joint_fixture, file_id=file_to_register.file_id, final_status="uploaded"
-        )
-
-    # check for the  events:
-    assert len(recorder.recorded_events) == 1
-    assert (
-        recorder.recorded_events[0].type_
-        == joint_fixture.config.upload_received_event_type
-    )
-    payload = event_schemas.FileUploadReceived(**recorder.recorded_events[0].payload)
-    assert payload.file_id == file_to_register.file_id
-    assert payload.expected_decrypted_sha256 == file_to_register.decrypted_sha256
 
     # publish an event to mark the upload as accepted:
     acceptance_event = event_schemas.FileInternallyRegistered(
@@ -192,3 +203,40 @@ async def test_happy_journey(joint_fixture: JointFixture):  # noqa: F405
     response = await joint_fixture.rest_client.get(f"/uploads/{latest_upload_id}")
     assert response.status_code == status.HTTP_200_OK
     assert response.json()["status"] == "accepted"
+
+
+@pytest.mark.asyncio
+async def test_unhappy_journey(joint_fixture: JointFixture):  # noqa: F405
+    """Test the typical journey through the service's APIs, but reject the upload
+    attempt due to a file validation error"""
+
+    file_to_register, event_subscriber = await run_until_uploaded(
+        joint_fixture=joint_fixture
+    )
+
+    # publish an event to mark the upload as rejected due to validation failure
+    failure_event = event_schemas.FileUploadValidationFailure(
+        file_id=file_to_register.file_id,
+        upload_date=datetime.utcnow().isoformat(),
+        reason="Sorry, but this has to fail.",
+    )
+
+    await joint_fixture.kafka.publish_event(
+        payload=json.loads(failure_event.json()),
+        type_=joint_fixture.config.validation_failure_event_type,
+        topic=joint_fixture.config.validation_failure_event_topic,
+    )
+
+    # consume the validation failure event:
+    await event_subscriber.run(forever=False)
+
+    # make sure that the latest upload of the corresponding file was marked as rejected:
+    # (first get the ID of the latest upload for that file:)
+    response = await joint_fixture.rest_client.get(f"/files/{file_to_register.file_id}")
+    assert response.status_code == status.HTTP_200_OK
+    latest_upload_id = response.json()["latest_upload_id"]
+
+    # (Then get details on that upload:)
+    response = await joint_fixture.rest_client.get(f"/uploads/{latest_upload_id}")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["status"] == "rejected"

--- a/ucs/__init__.py
+++ b/ucs/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ucs/__init__.py
+++ b/ucs/__init__.py
@@ -15,4 +15,4 @@
 
 """The package implements a service that manages uploads to a S3 inbox bucket."""
 
-__version__ = "0.4.3"
+__version__ = "0.5.0"

--- a/ucs/__main__.py
+++ b/ucs/__main__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ucs/adapters/__init__.py
+++ b/ucs/adapters/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ucs/adapters/inbound/__init__.py
+++ b/ucs/adapters/inbound/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ucs/adapters/inbound/akafka.py
+++ b/ucs/adapters/inbound/akafka.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ucs/adapters/inbound/akafka.py
+++ b/ucs/adapters/inbound/akafka.py
@@ -62,13 +62,13 @@ class EventSubTranslatorConfig(BaseSettings):
         ),
         example="file_registered",
     )
-    validation_failure_event_topic: str = Field(
+    upload_rejected_event_topic: str = Field(
         ...,
-        description="Name of the topic used for events informing about the outcome of "
-        + "file validations.",
+        description="Name of the topic used for events informing about rejection of an "
+        + "upload by downstream services due to validation failure.",
         example="file_interrogation",
     )
-    validation_failure_event_type: str = Field(
+    upload_rejected_event_type: str = Field(
         ...,
         description="The type used for events informing about the failure of a file validation.",
         example="file_validation_failure",
@@ -90,12 +90,12 @@ class EventSubTranslator(EventSubscriberProtocol):
         self.topics_of_interest = [
             config.file_metadata_event_topic,
             config.upload_accepted_event_topic,
-            config.validation_failure_event_topic,
+            config.upload_rejected_event_topic,
         ]
         self.types_of_interest = [
             config.file_metadata_event_type,
             config.upload_accepted_event_type,
-            config.validation_failure_event_type,
+            config.upload_rejected_event_type,
         ]
 
         self._file_metadata_service = file_metadata_service
@@ -152,7 +152,7 @@ class EventSubTranslator(EventSubscriberProtocol):
             await self._consume_file_metadata(payload=payload)
         elif type_ == self._config.upload_accepted_event_type:
             await self._consume_upload_accepted(payload=payload)
-        elif type_ == self._config.validation_failure_event_type:
+        elif type_ == self._config.upload_rejected_event_type:
             await self._consume_validation_failure(payload=payload)
         else:
             raise RuntimeError(f"Unexpected event of type: {type_}")

--- a/ucs/adapters/inbound/akafka.py
+++ b/ucs/adapters/inbound/akafka.py
@@ -52,7 +52,7 @@ class EventSubTranslatorConfig(BaseSettings):
             "Name of the topic to receive event that indicate that an upload was"
             + " by downstream services."
         ),
-        example="file_ingestion",
+        example="internal_file_registry",
     )
     upload_accepted_event_type: str = Field(
         ...,
@@ -60,7 +60,18 @@ class EventSubTranslatorConfig(BaseSettings):
             "The type used for event that indicate that an upload was by downstream"
             + " services."
         ),
-        example="file_upload_accepted",
+        example="file_registered",
+    )
+    validation_failure_event_topic: str = Field(
+        ...,
+        description="Name of the topic used for events informing about the outcome of "
+        + "file validations.",
+        example="file_interrogation",
+    )
+    validation_failure_event_type: str = Field(
+        ...,
+        description="The type used for events informing about the failure of a file validation.",
+        example="file_validation_failure",
     )
 
 
@@ -79,10 +90,12 @@ class EventSubTranslator(EventSubscriberProtocol):
         self.topics_of_interest = [
             config.file_metadata_event_topic,
             config.upload_accepted_event_topic,
+            config.validation_failure_event_topic,
         ]
         self.types_of_interest = [
             config.file_metadata_event_type,
             config.upload_accepted_event_type,
+            config.validation_failure_event_type,
         ]
 
         self._file_metadata_service = file_metadata_service
@@ -117,6 +130,15 @@ class EventSubTranslator(EventSubscriberProtocol):
 
         await self._upload_service.accept_latest(file_id=validated_payload.file_id)
 
+    async def _consume_validation_failure(self, *, payload: JsonObject) -> None:
+        "Consume file validation failure events."
+
+        validated_payload = get_validated_payload(
+            payload=payload, schema=event_schemas.FileUploadValidationFailure
+        )
+
+        await self._upload_service.reject_latest(file_id=validated_payload.file_id)
+
     async def _consume_validated(
         self,
         *,
@@ -130,5 +152,7 @@ class EventSubTranslator(EventSubscriberProtocol):
             await self._consume_file_metadata(payload=payload)
         elif type_ == self._config.upload_accepted_event_type:
             await self._consume_upload_accepted(payload=payload)
+        elif type_ == self._config.validation_failure_event_type:
+            await self._consume_validation_failure(payload=payload)
         else:
             raise RuntimeError(f"Unexpected event of type: {type_}")

--- a/ucs/adapters/inbound/fastapi_/__init__.py
+++ b/ucs/adapters/inbound/fastapi_/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ucs/adapters/inbound/fastapi_/custom_openapi.py
+++ b/ucs/adapters/inbound/fastapi_/custom_openapi.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ucs/adapters/inbound/fastapi_/http_exceptions.py
+++ b/ucs/adapters/inbound/fastapi_/http_exceptions.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ucs/adapters/inbound/fastapi_/rest_models.py
+++ b/ucs/adapters/inbound/fastapi_/rest_models.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ucs/adapters/inbound/fastapi_/routes.py
+++ b/ucs/adapters/inbound/fastapi_/routes.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ucs/adapters/outbound/__init__.py
+++ b/ucs/adapters/outbound/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ucs/adapters/outbound/akafka.py
+++ b/ucs/adapters/outbound/akafka.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ucs/adapters/outbound/akafka.py
+++ b/ucs/adapters/outbound/akafka.py
@@ -30,14 +30,15 @@ class EventPubTanslatorConfig(BaseSettings):
     """Config for publishing file upload-related events."""
 
     upload_received_event_topic: str = Field(
-        "file_uploads",
-        description=(
-            "Name of the topic to publish event that inform about new file uploads."
-        ),
+        ...,
+        description="Name of the topic to publish event that inform about new file "
+        + "uploads.",
+        example="file_uploads",
     )
     upload_received_event_type: str = Field(
-        "file_upload_received",
+        ...,
         description="The type to use for event that inform about new file uploads.",
+        example="file_upload_received",
     )
 
 

--- a/ucs/adapters/outbound/akafka.py
+++ b/ucs/adapters/outbound/akafka.py
@@ -31,7 +31,7 @@ class EventPubTanslatorConfig(BaseSettings):
 
     upload_received_event_topic: str = Field(
         ...,
-        description="Name of the topic to publish event that inform about new file "
+        description="Name of the topic to publish events that inform about new file "
         + "uploads.",
         example="file_uploads",
     )

--- a/ucs/adapters/outbound/dao.py
+++ b/ucs/adapters/outbound/dao.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ucs/adapters/outbound/s3.py
+++ b/ucs/adapters/outbound/s3.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ucs/cli.py
+++ b/ucs/cli.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ucs/config.py
+++ b/ucs/config.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ucs/container.py
+++ b/ucs/container.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ucs/core/__init__.py
+++ b/ucs/core/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ucs/core/file_service.py
+++ b/ucs/core/file_service.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ucs/core/models.py
+++ b/ucs/core/models.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ucs/core/upload_service.py
+++ b/ucs/core/upload_service.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ucs/core/upload_service.py
+++ b/ucs/core/upload_service.py
@@ -365,7 +365,7 @@ class UploadService(UploadServicePort):
 
     async def reject_latest(self, *, file_id: str) -> None:
         """
-        Accept the latest multi-part upload for the given file.
+        Reject the latest multi-part upload for the given file.
 
         Here the file ID is used, as this method is triggered by downstream services
         that only know the file ID not the upload attempt.

--- a/ucs/main.py
+++ b/ucs/main.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ucs/ports/__init__.py
+++ b/ucs/ports/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ucs/ports/inbound/__init__.py
+++ b/ucs/ports/inbound/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ucs/ports/inbound/file_service.py
+++ b/ucs/ports/inbound/file_service.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ucs/ports/inbound/upload_service.py
+++ b/ucs/ports/inbound/upload_service.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ucs/ports/inbound/upload_service.py
+++ b/ucs/ports/inbound/upload_service.py
@@ -182,7 +182,7 @@ class UploadServicePort(ABC):
     @abstractmethod
     async def reject_latest(self, *, file_id: str) -> None:
         """
-        Accept the latest multi-part upload for the given file.
+        Reject the latest multi-part upload for the given file.
 
         Here the file ID is used, as this method is triggered by downstream services
         that only know the file ID not the upload attempt.

--- a/ucs/ports/outbound/__init__.py
+++ b/ucs/ports/outbound/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ucs/ports/outbound/dao.py
+++ b/ucs/ports/outbound/dao.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ucs/ports/outbound/event_pub.py
+++ b/ucs/ports/outbound/event_pub.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ucs/ports/outbound/storage.py
+++ b/ucs/ports/outbound/storage.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
```
Replaced event_type/topic defaults with examples
Added validation_failure event handling (reject upload)
Added test case for unhappy path

Co-authored-by: Moritz Hahn <Moritz.Hahn@uni-tuebingen.de>
Co-authored-by: Kersten Breuer <kersten-breuer@outlook.com>
```

upload_rejected_event_type/type might be a more apt description from the service's perspective for what ist currently validation_failure_event_topic/type.
Just give me a heads up, if I should change that.