### PR TITLE
Implement module-scope fixtures (GSI 274)

### DIFF
--- a/.static_files
+++ b/.static_files
@@ -15,6 +15,7 @@
 scripts/script_utils/__init__.py
 scripts/script_utils/cli.py
 
+scripts/__init__.py
 scripts/license_checker.py
 scripts/get_package_name.py
 scripts/update_config_docs.py

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Scripts and utils used during development or in CI pipelines."""

--- a/scripts/update_template_files.py
+++ b/scripts/update_template_files.py
@@ -33,7 +33,7 @@ from pathlib import Path
 try:
     from script_utils.cli import echo_failure, echo_success, run
 except ImportError:
-    echo_failure = echo_success = print  # type: ignore
+    echo_failure = echo_success = print
 
     def run(main_fn):
         """Run main function without cli tools (typer)."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,8 +36,8 @@ include_package_data = True
 packages = find:
 install_requires =
     typer==0.7.0
-    ghga-service-commons[api]==0.4.2
-    ghga-event-schemas==0.13.1
+    ghga-service-commons[api]==0.4.3
+    ghga-event-schemas==0.13.2
     hexkit[mongodb,s3,akafka]==0.10.1
 
 python_requires = >= 3.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     typer==0.7.0
     ghga-service-commons[api]==0.4.2
     ghga-event-schemas==0.13.1
-    hexkit[mongodb,s3,akafka]==0.10.0
+    hexkit[mongodb,s3,akafka]==0.10.1
 
 python_requires = >= 3.9
 

--- a/tests/fixtures/joint.py
+++ b/tests/fixtures/joint.py
@@ -64,7 +64,8 @@ class JointFixture:
 async def joint_fixture_function(
     mongodb_fixture: MongoDbFixture, kafka_fixture: KafkaFixture, s3_fixture: S3Fixture
 ) -> AsyncGenerator[JointFixture, None]:
-    """A fixture that embeds all other fixtures for API-level integration testing"""
+    """A fixture that embeds all other fixtures for API-level integration testing.
+    Produced by calling get_joint_fixture()"""
 
     # merge configs from different sources with the default one:
     config = get_config(

--- a/tests/fixtures/module_scope.py
+++ b/tests/fixtures/module_scope.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/fixtures/module_scope.py
+++ b/tests/fixtures/module_scope.py
@@ -1,0 +1,51 @@
+# Copyright 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Define fixtures with module scope"""
+
+import asyncio
+
+import pytest
+import pytest_asyncio
+from hexkit.providers.testing.fixtures import (
+    KafkaFixture,
+    MongoDbFixture,
+    S3Fixture,
+    get_fixture,
+)
+
+from tests.fixtures.joint import JointFixture, get_joint_fixture
+
+
+@pytest.fixture(scope="module")
+def event_loop():
+    """event loop fixture"""
+    loop = asyncio.get_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest_asyncio.fixture()
+async def reset_state(joint_fixture: JointFixture):
+    """Reset joint_fixture state before and after the beginning of the test function"""
+    await joint_fixture.clear_state()
+    yield
+    await joint_fixture.clear_state()
+
+
+kafka_fixture = get_fixture(KafkaFixture, "module")
+mongodb_fixture = get_fixture(MongoDbFixture, "module")
+s3_fixture = get_fixture(S3Fixture, "module")
+joint_fixture = get_joint_fixture("module")

--- a/tests/fixtures/module_scope.py
+++ b/tests/fixtures/module_scope.py
@@ -39,7 +39,7 @@ def event_loop():
 
 @pytest_asyncio.fixture()
 async def reset_state(joint_fixture: JointFixture):
-    """Reset joint_fixture state before and after the beginning of the test function"""
+    """Reset joint_fixture state before and after the test function"""
     await joint_fixture.clear_state()
     yield
     await joint_fixture.clear_state()

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -21,12 +21,20 @@ import pytest
 from fastapi import status
 
 from tests.fixtures.example_data import EXAMPLE_FILE, EXAMPLE_UPLOADS
-from tests.fixtures.joint import *  # noqa: 403
+from tests.fixtures.module_scope import (  # noqa: F401
+    JointFixture,
+    event_loop,
+    joint_fixture,
+    kafka_fixture,
+    mongodb_fixture,
+    reset_state,
+    s3_fixture,
+)
 from ucs.core import models
 
 
 @pytest.mark.asyncio
-async def test_get_health(joint_fixture: JointFixture):  # noqa: F405
+async def test_get_health(joint_fixture: JointFixture):  # noqa: F811
     """Test the GET /health endpoint"""
 
     response = await joint_fixture.rest_client.get("/health")
@@ -36,7 +44,9 @@ async def test_get_health(joint_fixture: JointFixture):  # noqa: F405
 
 
 @pytest.mark.asyncio
-async def test_get_file_metadata_not_found(joint_fixture: JointFixture):  # noqa: F405
+async def test_get_file_metadata_not_found(
+    joint_fixture: JointFixture, reset_state  # noqa: F811
+):
     """Test the get_file_metadata endpoint with an non-existing file id."""
 
     file_id = "myNonExistingFile001"
@@ -47,7 +57,9 @@ async def test_get_file_metadata_not_found(joint_fixture: JointFixture):  # noqa
 
 
 @pytest.mark.asyncio
-async def test_create_upload_not_found(joint_fixture: JointFixture):  # noqa: F405
+async def test_create_upload_not_found(
+    joint_fixture: JointFixture, reset_state  # noqa: F811
+):
     """Test the create_upload endpoint with an non-existing file id."""
 
     file_id = "myNonExistingFile001"
@@ -72,7 +84,9 @@ async def test_create_upload_not_found(joint_fixture: JointFixture):  # noqa: F4
 )
 @pytest.mark.asyncio
 async def test_create_upload_other_active(
-    existing_status: models.UploadStatus, joint_fixture: JointFixture  # noqa: F405
+    existing_status: models.UploadStatus,
+    joint_fixture: JointFixture,  # noqa: F811
+    reset_state,  # noqa: F811
 ):
     """Test the create_upload endpoint when there is another active update already
     existing."""
@@ -104,7 +118,9 @@ async def test_create_upload_other_active(
 )
 @pytest.mark.asyncio
 async def test_create_upload_accepted(
-    existing_status: models.UploadStatus, joint_fixture: JointFixture  # noqa: F405
+    existing_status: models.UploadStatus,
+    joint_fixture: JointFixture,  # noqa: F811
+    reset_state,  # noqa: F811
 ):
     """Test the create_upload endpoint when another update has already been accepted
     or is currently being evaluated."""
@@ -129,7 +145,9 @@ async def test_create_upload_accepted(
 
 
 @pytest.mark.asyncio
-async def test_get_upload_not_found(joint_fixture: JointFixture):  # noqa: F405
+async def test_get_upload_not_found(
+    joint_fixture: JointFixture, reset_state  # noqa: F811
+):
     """Test the get_upload endpoint with non-existing upload ID."""
 
     upload_id = "myNonExistingUpload001"
@@ -141,7 +159,7 @@ async def test_get_upload_not_found(joint_fixture: JointFixture):  # noqa: F405
 
 @pytest.mark.asyncio
 async def test_update_upload_status_not_found(
-    joint_fixture: JointFixture,  # noqa: F405
+    joint_fixture: JointFixture, reset_state  # noqa: F811
 ):
     """Test the update_upload_status endpoint with non existing upload ID."""
 
@@ -165,7 +183,9 @@ async def test_update_upload_status_not_found(
 )
 @pytest.mark.asyncio
 async def test_update_upload_status_invalid_new_status(
-    new_status: models.UploadStatus, joint_fixture: JointFixture  # noqa: F405
+    new_status: models.UploadStatus,
+    joint_fixture: JointFixture,  # noqa: F811
+    reset_state,  # noqa: F811
 ):
     """Test the update_upload_status endpoint with invalid new status values."""
 
@@ -190,7 +210,9 @@ async def test_update_upload_status_invalid_new_status(
 )
 @pytest.mark.asyncio
 async def test_update_upload_status_non_pending(
-    old_status: models.UploadStatus, joint_fixture: JointFixture  # noqa: F405
+    old_status: models.UploadStatus,
+    joint_fixture: JointFixture,  # noqa: F811
+    reset_state,  # noqa: F811
 ):
     """Test the update_upload_status endpoint on non pending upload."""
 
@@ -214,7 +236,7 @@ async def test_update_upload_status_non_pending(
 
 @pytest.mark.asyncio
 async def test_create_presigned_url_not_found(
-    joint_fixture: JointFixture,  # noqa: F405
+    joint_fixture: JointFixture, reset_state  # noqa: F811
 ):
     """Test the create_presigned_url endpoint with non existing upload ID."""
 

--- a/tests/test_typical_journey.py
+++ b/tests/test_typical_journey.py
@@ -18,27 +18,27 @@ service (incl. REST and event-driven APIs)."""
 
 import json
 from datetime import datetime
+from typing import Literal
 
-try:  # workaround for https://github.com/pydantic/pydantic/issues/5821
-    from typing_extensions import Literal
-except ImportError:
-    from typing import Literal  # type: ignore
-
-import nest_asyncio
 import pytest
 from fastapi import status
 from ghga_event_schemas import pydantic_ as event_schemas
 from hexkit.providers.s3.testutils import upload_part_via_url
 
 from tests.fixtures.example_data import EXAMPLE_FILE
-from tests.fixtures.joint import *  # noqa: 403
+from tests.fixtures.joint import (  # noqa: F401
+    JointFixture,
+    joint_fixture,
+    kafka_fixture,
+    mongodb_fixture,
+    s3_fixture,
+)
 
 # this is a temporary solution to run an event loop within another event loop
 # will be solved once transitioning to kafka:
-nest_asyncio.apply()
 
 
-async def run_until_uploaded(joint_fixture: JointFixture):  # noqa: F405
+async def run_until_uploaded(joint_fixture: JointFixture):  # noqa: F811
     """Run steps until uploaded data has been received and the upload attempt has been
     marked as uploaded"""
 
@@ -101,7 +101,7 @@ async def run_until_uploaded(joint_fixture: JointFixture):  # noqa: F405
 
 
 async def perform_upload(
-    joint_fixture: JointFixture,  # noqa: F405
+    joint_fixture: JointFixture,  # noqa: F811
     *,
     file_id: str,
     final_status: Literal["cancelled", "uploaded"],
@@ -168,7 +168,7 @@ async def perform_upload(
 
 
 @pytest.mark.asyncio
-async def test_happy_journey(joint_fixture: JointFixture):  # noqa: F405
+async def test_happy_journey(joint_fixture: JointFixture):  # noqa: F811
     """Test the typical anticipated/successful journey through the service's APIs."""
 
     file_to_register, event_subscriber = await run_until_uploaded(
@@ -212,7 +212,7 @@ async def test_happy_journey(joint_fixture: JointFixture):  # noqa: F405
 
 
 @pytest.mark.asyncio
-async def test_unhappy_journey(joint_fixture: JointFixture):  # noqa: F405
+async def test_unhappy_journey(joint_fixture: JointFixture):  # noqa: F811
     """Test the typical journey through the service's APIs, but reject the upload
     attempt due to a file validation error"""
 


### PR DESCRIPTION
I added a file `module_scoped.py`, containing:

- The module-scope versions of the fixtures,
- reset_state fixture that will call the reset functions for MongoDB, S3, and Kafka at the beginning and end of each test that uses it. 
- event_loop fixture with module scope

In `joint.py`, I changed the joint_fixture into a fixture function, which is then processed by the new function `get_joint_fixture()`. Below that, the normal/default function-scoped fixtures are declared. 
The test_typical_journey module only had two tests, so I didn't change anything beside the imports.
In test_edge_cases, I used the new module-scope fixtures.