### PR TITLE
Use module-scope fixture for testing (GSI 274)

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -32,7 +32,7 @@ jobs:
         name: Verify tag format
         # format must be compatible with semantic versioning
         run: |
-          SEMVER_REGEX="^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+          SEMVER_REGEX="^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
           if echo "${{ steps.get_version_tag.outputs.version }}" | grep -Eq "$SEMVER_REGEX"; then
             echo "Tag format is valid"
           else

--- a/.static_files
+++ b/.static_files
@@ -15,6 +15,7 @@
 scripts/script_utils/__init__.py
 scripts/script_utils/cli.py
 
+scripts/__init__.py
 scripts/license_checker.py
 scripts/get_package_name.py
 scripts/update_config_docs.py

--- a/.static_files
+++ b/.static_files
@@ -16,6 +16,7 @@ scripts/script_utils/__init__.py
 scripts/script_utils/cli.py
 
 scripts/__init__.py
+scripts/update_all.py
 scripts/license_checker.py
 scripts/get_package_name.py
 scripts/update_config_docs.py

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/upload-controller-service):
 ```bash
-docker pull ghga/upload-controller-service:0.6.0
+docker pull ghga/upload-controller-service:0.6.1
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/upload-controller-service:0.6.0 .
+docker build -t ghga/upload-controller-service:0.6.1 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -32,7 +32,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/upload-controller-service:0.6.0 --help
+docker run -p 8080:8080 ghga/upload-controller-service:0.6.1 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -397,7 +397,7 @@ info:
   description: A service managing uploads of file objects to an S3-compatible Object
     Storage.
   title: Upload Controller Service
-  version: 0.6.0
+  version: 0.6.1
 openapi: 3.0.2
 paths:
   /files/{file_id}:

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Scripts and utils used during development or in CI pipelines."""

--- a/scripts/update_all.py
+++ b/scripts/update_all.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Run all update scripts that are present in the repository in the correct order"""
+
+try:
+    from scripts.update_template_files import main as update_template
+except ImportError:
+    pass
+else:
+    print("Pulling in updates from template repository")
+    update_template()
+
+try:
+    from scripts.update_config_docs import main as update_config
+except ImportError:
+    pass
+else:
+    print("Updating config docs")
+    update_config()
+
+try:
+    from scripts.update_openapi_docs import main as update_openapi
+except ImportError:
+    pass
+else:
+    print("Updating OpenAPI docs")
+    update_openapi()
+
+try:
+    from scripts.update_readme import main as update_readme
+except ImportError:
+    pass
+else:
+    print("Updating README")
+    update_readme()

--- a/scripts/update_template_files.py
+++ b/scripts/update_template_files.py
@@ -33,7 +33,7 @@ from pathlib import Path
 try:
     from script_utils.cli import echo_failure, echo_success, run
 except ImportError:
-    echo_failure = echo_success = print  # type: ignore
+    echo_failure = echo_success = print
 
     def run(main_fn):
         """Run main function without cli tools (typer)."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ packages = find:
 install_requires =
     typer==0.7.0
     ghga-service-commons[api]==0.4.3
-    ghga-event-schemas==0.13.2
+    ghga-event-schemas==0.13.3
     hexkit[mongodb,s3,akafka]==0.10.2
 
 python_requires = >= 3.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,9 +36,9 @@ include_package_data = True
 packages = find:
 install_requires =
     typer==0.7.0
-    ghga-service-commons[api]==0.4.2
-    ghga-event-schemas==0.13.1
-    hexkit[mongodb,s3,akafka]==0.10.0
+    ghga-service-commons[api]==0.4.3
+    ghga-event-schemas==0.13.2
+    hexkit[mongodb,s3,akafka]==0.10.2
 
 python_requires = >= 3.9
 
@@ -47,11 +47,7 @@ console_scripts =
     ucs = ucs.__main__:cli
 
 [options.extras_require]
-dev =
-    nest-asyncio==1.5.6
 all =
-    %(dev)s
-
 
 [options.packages.find]
 exclude = tests

--- a/tests/fixtures/example_data.py
+++ b/tests/fixtures/example_data.py
@@ -15,8 +15,7 @@
 
 """Example data used for testing."""
 
-from datetime import datetime
-
+from ghga_service_commons.utils.utc_dates import now_as_utc
 from hexkit.providers.s3.testutils import TEST_FILE_PATHS, FileObject
 
 from tests.fixtures.config import DEFAULT_CONFIG
@@ -53,7 +52,7 @@ EXAMPLE_UPLOAD = models.UploadAttempt(
     object_id="object001",
     status=models.UploadStatus.PENDING,
     part_size=1234,
-    creation_date=datetime.now(),
+    creation_date=now_as_utc(),
     submitter_public_key="test-key",
     completion_date=None,
 )

--- a/tests/fixtures/joint.py
+++ b/tests/fixtures/joint.py
@@ -30,10 +30,7 @@ import httpx
 import pytest_asyncio
 from ghga_service_commons.api.testing import get_free_port
 from hexkit.providers.akafka.testutils import KafkaFixture, get_kafka_fixture
-from hexkit.providers.mongodb.testutils import (  # F401
-    MongoDbFixture,
-    get_mongodb_fixture,
-)
+from hexkit.providers.mongodb.testutils import MongoDbFixture, get_mongodb_fixture
 from hexkit.providers.s3.testutils import S3Fixture, get_s3_fixture
 from pytest_asyncio.plugin import _ScopeName
 
@@ -53,6 +50,12 @@ class JointFixture:
     kafka: KafkaFixture
     rest_client: httpx.AsyncClient
     s3: S3Fixture
+
+    async def reset_state(self):
+        """Completely reset fixture states"""
+        await self.s3.empty_buckets()
+        self.mongodb.empty_collections()
+        self.kafka.delete_topics()
 
 
 async def joint_fixture_function(

--- a/tests/fixtures/joint.py
+++ b/tests/fixtures/joint.py
@@ -29,9 +29,13 @@ from typing import AsyncGenerator
 import httpx
 import pytest_asyncio
 from ghga_service_commons.api.testing import get_free_port
-from hexkit.providers.akafka.testutils import KafkaFixture, kafka_fixture
-from hexkit.providers.mongodb.testutils import MongoDbFixture, mongodb_fixture  # F401
-from hexkit.providers.s3.testutils import S3Fixture, s3_fixture
+from hexkit.providers.akafka.testutils import KafkaFixture, get_kafka_fixture
+from hexkit.providers.mongodb.testutils import (  # F401
+    MongoDbFixture,
+    get_mongodb_fixture,
+)
+from hexkit.providers.s3.testutils import S3Fixture, get_s3_fixture
+from pytest_asyncio.plugin import _ScopeName
 
 from tests.fixtures.config import get_config
 from ucs.config import Config
@@ -51,11 +55,13 @@ class JointFixture:
     s3: S3Fixture
 
 
-@pytest_asyncio.fixture
-async def joint_fixture(
+async def joint_fixture_function(
     mongodb_fixture: MongoDbFixture, kafka_fixture: KafkaFixture, s3_fixture: S3Fixture
 ) -> AsyncGenerator[JointFixture, None]:
-    """A fixture that embeds all other fixtures for API-level integration testing"""
+    """A fixture that embeds all other fixtures for API-level integration testing.
+
+    **Do not call directly** Instead, use get_joint_fixture().
+    """
 
     # merge configs from different sources with the default one:
     config = get_config(
@@ -80,3 +86,14 @@ async def joint_fixture(
                 rest_client=rest_client,
                 s3=s3_fixture,
             )
+
+
+def get_joint_fixture(scope: _ScopeName = "function"):
+    """Produce a joint fixture with desired scope"""
+    return pytest_asyncio.fixture(joint_fixture_function, scope=scope)
+
+
+joint_fixture = get_joint_fixture()
+mongodb_fixture = get_mongodb_fixture()
+kafka_fixture = get_kafka_fixture()
+s3_fixture = get_s3_fixture()

--- a/tests/fixtures/module_scope_fixtures.py
+++ b/tests/fixtures/module_scope_fixtures.py
@@ -24,14 +24,12 @@ from hexkit.providers.testing.utils import get_event_loop
 from tests.fixtures.joint import JointFixture, get_joint_fixture
 
 
-@pytest_asyncio.fixture
+@pytest_asyncio.fixture(autouse=True)
 async def reset_state(joint_fixture: JointFixture):  # noqa: F811
     """Clear joint_fixture state before and after tests that use this fixture.
 
     This is a function-level fixture because it needs to run in each test.
     """
-    await joint_fixture.reset_state()
-    yield
     await joint_fixture.reset_state()
 
 

--- a/tests/fixtures/module_scope_fixtures.py
+++ b/tests/fixtures/module_scope_fixtures.py
@@ -14,18 +14,29 @@
 # limitations under the License.
 
 """Contains module-scoped fixtures"""
-
+import pytest_asyncio
 from hexkit.providers.akafka.testutils import get_kafka_fixture
 from hexkit.providers.mongodb.testutils import get_mongodb_fixture
 from hexkit.providers.s3.testutils import get_s3_fixture
 from hexkit.providers.testing.utils import get_event_loop
 
-from tests.fixtures.joint import get_joint_fixture
+from tests.fixtures.joint import JointFixture, get_joint_fixture
 
 SCOPE = "module"
 
-event_loop = get_event_loop(SCOPE)
 
+@pytest_asyncio.fixture
+async def reset_state(joint_fixture: JointFixture):  # noqa: F811
+    """Clear joint_fixture state before and after tests that use this fixture.
+
+    This is a function-level fixture because it needs to run in each test.
+    """
+    await joint_fixture.reset_state()
+    yield
+    await joint_fixture.reset_state()
+
+
+event_loop = get_event_loop(SCOPE)
 mongodb_fixture = get_mongodb_fixture(SCOPE)
 kafka_fixture = get_kafka_fixture(SCOPE)
 s3_fixture = get_s3_fixture(SCOPE)

--- a/tests/fixtures/module_scope_fixtures.py
+++ b/tests/fixtures/module_scope_fixtures.py
@@ -1,0 +1,32 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contains module-scoped fixtures"""
+
+from hexkit.providers.akafka.testutils import get_kafka_fixture
+from hexkit.providers.mongodb.testutils import get_mongodb_fixture
+from hexkit.providers.s3.testutils import get_s3_fixture
+from hexkit.providers.testing.utils import get_event_loop
+
+from tests.fixtures.joint import get_joint_fixture
+
+SCOPE = "module"
+
+event_loop = get_event_loop(SCOPE)
+
+mongodb_fixture = get_mongodb_fixture(SCOPE)
+kafka_fixture = get_kafka_fixture(SCOPE)
+s3_fixture = get_s3_fixture(SCOPE)
+joint_fixture = get_joint_fixture(SCOPE)

--- a/tests/fixtures/module_scope_fixtures.py
+++ b/tests/fixtures/module_scope_fixtures.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 """Contains module-scoped fixtures"""
+
 import pytest_asyncio
 from hexkit.providers.akafka.testutils import get_kafka_fixture
 from hexkit.providers.mongodb.testutils import get_mongodb_fixture
@@ -21,8 +22,6 @@ from hexkit.providers.s3.testutils import get_s3_fixture
 from hexkit.providers.testing.utils import get_event_loop
 
 from tests.fixtures.joint import JointFixture, get_joint_fixture
-
-SCOPE = "module"
 
 
 @pytest_asyncio.fixture
@@ -36,8 +35,8 @@ async def reset_state(joint_fixture: JointFixture):  # noqa: F811
     await joint_fixture.reset_state()
 
 
-event_loop = get_event_loop(SCOPE)
-mongodb_fixture = get_mongodb_fixture(SCOPE)
-kafka_fixture = get_kafka_fixture(SCOPE)
-s3_fixture = get_s3_fixture(SCOPE)
-joint_fixture = get_joint_fixture(SCOPE)
+event_loop = get_event_loop("module")
+mongodb_fixture = get_mongodb_fixture("module")
+kafka_fixture = get_kafka_fixture("module")
+s3_fixture = get_s3_fixture("module")
+joint_fixture = get_joint_fixture("module")

--- a/tests/fixtures/module_scope_fixtures.py
+++ b/tests/fixtures/module_scope_fixtures.py
@@ -26,7 +26,7 @@ from tests.fixtures.joint import JointFixture, get_joint_fixture
 
 @pytest_asyncio.fixture(autouse=True)
 async def reset_state(joint_fixture: JointFixture):  # noqa: F811
-    """Clear joint_fixture state before and after tests that use this fixture.
+    """Clear joint_fixture state before tests that use this fixture.
 
     This is a function-level fixture because it needs to run in each test.
     """

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -21,13 +21,24 @@ import pytest
 from fastapi import status
 
 from tests.fixtures.example_data import EXAMPLE_FILE, EXAMPLE_UPLOADS
-from tests.fixtures.joint import *  # noqa: 403
+from tests.fixtures.module_scope_fixtures import (  # noqa: F401
+    JointFixture,
+    event_loop,
+    joint_fixture,
+    kafka_fixture,
+    mongodb_fixture,
+    reset_state,
+    s3_fixture,
+)
 from ucs.core import models
 
 
 @pytest.mark.asyncio
-async def test_get_health(joint_fixture: JointFixture):  # noqa: F405
-    """Test the GET /health endpoint"""
+async def test_get_health(joint_fixture: JointFixture):  # noqa: F811
+    """Test the GET /health endpoint.
+
+    reset_state fixture isn't needed because the test is unaffected by state.
+    """
 
     response = await joint_fixture.rest_client.get("/health")
 
@@ -36,7 +47,9 @@ async def test_get_health(joint_fixture: JointFixture):  # noqa: F405
 
 
 @pytest.mark.asyncio
-async def test_get_file_metadata_not_found(joint_fixture: JointFixture):  # noqa: F405
+async def test_get_file_metadata_not_found(
+    joint_fixture: JointFixture, reset_state  # noqa: F811
+):
     """Test the get_file_metadata endpoint with an non-existing file id."""
 
     file_id = "myNonExistingFile001"
@@ -47,7 +60,9 @@ async def test_get_file_metadata_not_found(joint_fixture: JointFixture):  # noqa
 
 
 @pytest.mark.asyncio
-async def test_create_upload_not_found(joint_fixture: JointFixture):  # noqa: F405
+async def test_create_upload_not_found(
+    joint_fixture: JointFixture, reset_state  # noqa: F811
+):
     """Test the create_upload endpoint with an non-existing file id."""
 
     file_id = "myNonExistingFile001"
@@ -72,7 +87,9 @@ async def test_create_upload_not_found(joint_fixture: JointFixture):  # noqa: F4
 )
 @pytest.mark.asyncio
 async def test_create_upload_other_active(
-    existing_status: models.UploadStatus, joint_fixture: JointFixture  # noqa: F405
+    existing_status: models.UploadStatus,
+    joint_fixture: JointFixture,  # noqa: F811
+    reset_state,  # noqa: F811
 ):
     """Test the create_upload endpoint when there is another active update already
     existing."""
@@ -104,7 +121,9 @@ async def test_create_upload_other_active(
 )
 @pytest.mark.asyncio
 async def test_create_upload_accepted(
-    existing_status: models.UploadStatus, joint_fixture: JointFixture  # noqa: F405
+    existing_status: models.UploadStatus,
+    joint_fixture: JointFixture,  # noqa: F811
+    reset_state,  # noqa: F811
 ):
     """Test the create_upload endpoint when another update has already been accepted
     or is currently being evaluated."""
@@ -129,7 +148,9 @@ async def test_create_upload_accepted(
 
 
 @pytest.mark.asyncio
-async def test_get_upload_not_found(joint_fixture: JointFixture):  # noqa: F405
+async def test_get_upload_not_found(
+    joint_fixture: JointFixture, reset_state  # noqa: F811
+):
     """Test the get_upload endpoint with non-existing upload ID."""
 
     upload_id = "myNonExistingUpload001"
@@ -141,7 +162,7 @@ async def test_get_upload_not_found(joint_fixture: JointFixture):  # noqa: F405
 
 @pytest.mark.asyncio
 async def test_update_upload_status_not_found(
-    joint_fixture: JointFixture,  # noqa: F405
+    joint_fixture: JointFixture, reset_state  # noqa: F811
 ):
     """Test the update_upload_status endpoint with non existing upload ID."""
 
@@ -165,7 +186,9 @@ async def test_update_upload_status_not_found(
 )
 @pytest.mark.asyncio
 async def test_update_upload_status_invalid_new_status(
-    new_status: models.UploadStatus, joint_fixture: JointFixture  # noqa: F405
+    new_status: models.UploadStatus,
+    joint_fixture: JointFixture,  # noqa: F811
+    reset_state,  # noqa: F811
 ):
     """Test the update_upload_status endpoint with invalid new status values."""
 
@@ -190,7 +213,9 @@ async def test_update_upload_status_invalid_new_status(
 )
 @pytest.mark.asyncio
 async def test_update_upload_status_non_pending(
-    old_status: models.UploadStatus, joint_fixture: JointFixture  # noqa: F405
+    old_status: models.UploadStatus,
+    joint_fixture: JointFixture,  # noqa: F811
+    reset_state,  # noqa: F811
 ):
     """Test the update_upload_status endpoint on non pending upload."""
 
@@ -214,7 +239,7 @@ async def test_update_upload_status_non_pending(
 
 @pytest.mark.asyncio
 async def test_create_presigned_url_not_found(
-    joint_fixture: JointFixture,  # noqa: F405
+    joint_fixture: JointFixture, reset_state  # noqa: F811
 ):
     """Test the create_presigned_url endpoint with non existing upload ID."""
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -13,7 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test edge cases of interacting with the services API."""
+"""Test edge cases of interacting with the services API.
+
+Note: This test module uses the module-scoped fixtures.
+"""
 
 import json
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -50,9 +50,7 @@ async def test_get_health(joint_fixture: JointFixture):  # noqa: F811
 
 
 @pytest.mark.asyncio
-async def test_get_file_metadata_not_found(
-    joint_fixture: JointFixture, reset_state  # noqa: F811
-):
+async def test_get_file_metadata_not_found(joint_fixture: JointFixture):  # noqa: F811
     """Test the get_file_metadata endpoint with an non-existing file id."""
 
     file_id = "myNonExistingFile001"
@@ -63,9 +61,7 @@ async def test_get_file_metadata_not_found(
 
 
 @pytest.mark.asyncio
-async def test_create_upload_not_found(
-    joint_fixture: JointFixture, reset_state  # noqa: F811
-):
+async def test_create_upload_not_found(joint_fixture: JointFixture):  # noqa: F811
     """Test the create_upload endpoint with an non-existing file id."""
 
     file_id = "myNonExistingFile001"
@@ -92,7 +88,6 @@ async def test_create_upload_not_found(
 async def test_create_upload_other_active(
     existing_status: models.UploadStatus,
     joint_fixture: JointFixture,  # noqa: F811
-    reset_state,  # noqa: F811
 ):
     """Test the create_upload endpoint when there is another active update already
     existing."""
@@ -126,7 +121,6 @@ async def test_create_upload_other_active(
 async def test_create_upload_accepted(
     existing_status: models.UploadStatus,
     joint_fixture: JointFixture,  # noqa: F811
-    reset_state,  # noqa: F811
 ):
     """Test the create_upload endpoint when another update has already been accepted
     or is currently being evaluated."""
@@ -151,9 +145,7 @@ async def test_create_upload_accepted(
 
 
 @pytest.mark.asyncio
-async def test_get_upload_not_found(
-    joint_fixture: JointFixture, reset_state  # noqa: F811
-):
+async def test_get_upload_not_found(joint_fixture: JointFixture):  # noqa: F811
     """Test the get_upload endpoint with non-existing upload ID."""
 
     upload_id = "myNonExistingUpload001"
@@ -165,7 +157,7 @@ async def test_get_upload_not_found(
 
 @pytest.mark.asyncio
 async def test_update_upload_status_not_found(
-    joint_fixture: JointFixture, reset_state  # noqa: F811
+    joint_fixture: JointFixture,  # noqa: F811
 ):
     """Test the update_upload_status endpoint with non existing upload ID."""
 
@@ -191,7 +183,6 @@ async def test_update_upload_status_not_found(
 async def test_update_upload_status_invalid_new_status(
     new_status: models.UploadStatus,
     joint_fixture: JointFixture,  # noqa: F811
-    reset_state,  # noqa: F811
 ):
     """Test the update_upload_status endpoint with invalid new status values."""
 
@@ -218,7 +209,6 @@ async def test_update_upload_status_invalid_new_status(
 async def test_update_upload_status_non_pending(
     old_status: models.UploadStatus,
     joint_fixture: JointFixture,  # noqa: F811
-    reset_state,  # noqa: F811
 ):
     """Test the update_upload_status endpoint on non pending upload."""
 
@@ -242,7 +232,7 @@ async def test_update_upload_status_non_pending(
 
 @pytest.mark.asyncio
 async def test_create_presigned_url_not_found(
-    joint_fixture: JointFixture, reset_state  # noqa: F811
+    joint_fixture: JointFixture,  # noqa: F811
 ):
     """Test the create_presigned_url endpoint with non existing upload ID."""
 

--- a/tests/test_typical_journey.py
+++ b/tests/test_typical_journey.py
@@ -20,12 +20,12 @@ service (incl. REST and event-driven APIs).
 """
 
 import json
-from datetime import datetime
 from typing import Literal
 
 import pytest
 from fastapi import status
 from ghga_event_schemas import pydantic_ as event_schemas
+from ghga_service_commons.utils.utc_dates import now_as_utc
 from hexkit.providers.s3.testutils import upload_part_via_url
 
 from tests.fixtures.example_data import EXAMPLE_FILE
@@ -185,7 +185,7 @@ async def test_happy_journey(joint_fixture: JointFixture):  # noqa: F811
         file_id=file_to_register.file_id,
         object_id="objectid",
         bucket_id="test-permanent",
-        upload_date=datetime.utcnow().isoformat(),
+        upload_date=now_as_utc().isoformat(),
         decrypted_sha256=file_to_register.decrypted_sha256,
         decrypted_size=file_to_register.decrypted_size,
         decryption_secret_id="some-secret",
@@ -233,7 +233,7 @@ async def test_unhappy_journey(joint_fixture: JointFixture):  # noqa: F811
         file_id=file_to_register.file_id,
         object_id="objectid",
         bucket_id="test-staging",
-        upload_date=datetime.utcnow().isoformat(),
+        upload_date=now_as_utc().isoformat(),
         reason="Sorry, but this has to fail.",
     )
 

--- a/tests/test_typical_journey.py
+++ b/tests/test_typical_journey.py
@@ -13,8 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Simulate client behavior and test a typical journey through the APIs exposed by this
-service (incl. REST and event-driven APIs)."""
+"""Test happy/unhappy journey.
+
+Simulate client behavior and test a typical journey through the APIs exposed by this
+service (incl. REST and event-driven APIs).
+"""
 
 import json
 from datetime import datetime

--- a/ucs/__init__.py
+++ b/ucs/__init__.py
@@ -15,4 +15,4 @@
 
 """The package implements a service that manages uploads to a S3 inbox bucket."""
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/ucs/core/upload_service.py
+++ b/ucs/core/upload_service.py
@@ -17,9 +17,9 @@
 """The main upload handling logic."""
 
 import uuid
-from datetime import datetime
 from typing import Callable
 
+from ghga_service_commons.utils.utc_dates import now_as_utc
 from hexkit.utils import calc_part_size
 from pydantic import BaseSettings
 
@@ -260,7 +260,7 @@ class UploadService(UploadServicePort):
             object_id=object_id,
             status=models.UploadStatus.PENDING,
             part_size=part_size,
-            creation_date=datetime.utcnow(),
+            creation_date=now_as_utc(),
             submitter_public_key=submitter_public_key,
         )
 
@@ -335,7 +335,7 @@ class UploadService(UploadServicePort):
             ) from error
 
         # mark the upload as complete (uploaded) in the database:
-        completion_date = datetime.utcnow()
+        completion_date = now_as_utc()
         updated_upload = upload.copy(
             update={
                 "status": models.UploadStatus.UPLOADED,


### PR DESCRIPTION
Changed joint_fixture to joint_fixture_function and created a get_joint_fixture (so the same style as what is now in hexkit). 
Added `module_scope_fixtures.py` to contain the new fixtures.

The module-level fixtures greatly reduced the test duration for the edge case tests, but had little effect on the typical journey tests, so the latter remained mostly untouched. 