### PR TITLE
Clean inbox buckets

### DIFF
--- a/.devcontainer/.dev_config.yaml
+++ b/.devcontainer/.dev_config.yaml
@@ -7,6 +7,10 @@ object_storages:
       s3_endpoint_url: http://ucs:4566
       s3_access_key_id: test
       s3_secret_access_key: test
+files_to_delete_topic: file_deletions
+files_to_delete_type: file_deletion_requested
+file_deleted_event_topic: file_downloads
+file_deleted_event_type: file_deleted
 file_metadata_event_topic: metadata
 file_metadata_event_type: metadata_upsert
 upload_accepted_event_topic: internal_file_registry

--- a/.github/workflows/ci_workflow_dispatch.yaml
+++ b/.github/workflows/ci_workflow_dispatch.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   fetch-tag:
     runs-on: ubuntu-latest
-    if: ( github.event.action == 'workflow_dispatch' || github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'build') ) || ( github.event.action == 'labeled' && github.event.label.name == 'build' )
+    if:  github.event_name == 'workflow_dispatch' || ( github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'build') ) || ( github.event.action == 'labeled' && github.event.label.name == 'build' )
     steps:
       - id: fetch-tag
         uses: ghga-de/gh-action-fetch-tag@v1

--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ucs"
-version = "2.0.0"
+version = "2.1.0"
 description = "The Upload-Controller Service (UCS) manages uploads to a S3 inbox bucket."
 dependencies = [
     "ghga-service-commons[all]>=2.0.0",

--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ucs"
-version = "2.1.0"
+version = "3.0.0"
 description = "The Upload-Controller Service (UCS) manages uploads to a S3 inbox bucket."
 dependencies = [
     "ghga-service-commons[all]>=2.0.0",

--- a/README.md
+++ b/README.md
@@ -49,6 +49,26 @@ ucs --help
 ### Parameters
 
 The service requires the following configuration parameters:
+- **`file_deleted_event_topic`** *(string)*: Name of the topic used for events indicating that a file has been deleted.
+
+
+  Examples:
+
+  ```json
+  "file_downloads"
+  ```
+
+
+- **`file_deleted_event_type`** *(string)*: The type used for events indicating that a file has been deleted.
+
+
+  Examples:
+
+  ```json
+  "file_deleted"
+  ```
+
+
 - **`upload_received_event_topic`** *(string)*: Name of the topic to publish events that inform about new file uploads.
 
 
@@ -86,6 +106,26 @@ The service requires the following configuration parameters:
 
   ```json
   "file_metadata_upserts"
+  ```
+
+
+- **`files_to_delete_topic`** *(string)*: The name of the topic for events informing about files to be deleted.
+
+
+  Examples:
+
+  ```json
+  "file_deletions"
+  ```
+
+
+- **`files_to_delete_type`** *(string)*: The type used for events informing about a file to be deleted.
+
+
+  Examples:
+
+  ```json
+  "file_deletion_requested"
   ```
 
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/upload-controller-service):
 ```bash
-docker pull ghga/upload-controller-service:2.1.0
+docker pull ghga/upload-controller-service:3.0.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/upload-controller-service:2.1.0 .
+docker build -t ghga/upload-controller-service:3.0.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -32,7 +32,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/upload-controller-service:2.1.0 --help
+docker run -p 8080:8080 ghga/upload-controller-service:3.0.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/upload-controller-service):
 ```bash
-docker pull ghga/upload-controller-service:2.0.0
+docker pull ghga/upload-controller-service:2.1.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/upload-controller-service:2.0.0 .
+docker build -t ghga/upload-controller-service:2.1.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -32,7 +32,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/upload-controller-service:2.0.0 --help
+docker run -p 8080:8080 ghga/upload-controller-service:2.1.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/config_schema.json
+++ b/config_schema.json
@@ -97,6 +97,22 @@
   "additionalProperties": false,
   "description": "Modifies the orginal Settings class provided by the user",
   "properties": {
+    "file_deleted_event_topic": {
+      "description": "Name of the topic used for events indicating that a file has been deleted.",
+      "examples": [
+        "file_downloads"
+      ],
+      "title": "File Deleted Event Topic",
+      "type": "string"
+    },
+    "file_deleted_event_type": {
+      "description": "The type used for events indicating that a file has been deleted.",
+      "examples": [
+        "file_deleted"
+      ],
+      "title": "File Deleted Event Type",
+      "type": "string"
+    },
     "upload_received_event_topic": {
       "description": "Name of the topic to publish events that inform about new file uploads.",
       "examples": [
@@ -127,6 +143,22 @@
         "file_metadata_upserts"
       ],
       "title": "File Metadata Event Type",
+      "type": "string"
+    },
+    "files_to_delete_topic": {
+      "description": "The name of the topic for events informing about files to be deleted.",
+      "examples": [
+        "file_deletions"
+      ],
+      "title": "Files To Delete Topic",
+      "type": "string"
+    },
+    "files_to_delete_type": {
+      "description": "The type used for events informing about a file to be deleted.",
+      "examples": [
+        "file_deletion_requested"
+      ],
+      "title": "Files To Delete Type",
       "type": "string"
     },
     "upload_accepted_event_topic": {
@@ -412,10 +444,14 @@
     }
   },
   "required": [
+    "file_deleted_event_topic",
+    "file_deleted_event_type",
     "upload_received_event_topic",
     "upload_received_event_type",
     "file_metadata_event_topic",
     "file_metadata_event_type",
+    "files_to_delete_topic",
+    "files_to_delete_type",
     "upload_accepted_event_topic",
     "upload_accepted_event_type",
     "upload_rejected_event_topic",

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -7,8 +7,12 @@ cors_allowed_origins: null
 db_connection_str: '**********'
 db_name: dev_db
 docs_url: /docs
+file_deleted_event_topic: file_downloads
+file_deleted_event_type: file_deleted
 file_metadata_event_topic: metadata
 file_metadata_event_type: metadata_upsert
+files_to_delete_topic: file_deletions
+files_to_delete_type: file_deletion_requested
 generate_correlation_id: true
 host: 127.0.0.1
 kafka_security_protocol: PLAINTEXT

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -409,7 +409,7 @@ info:
   description: A service managing uploads of file objects to an S3-compatible Object
     Storage.
   title: Upload Controller Service
-  version: 2.0.0
+  version: 2.1.0
 openapi: 3.1.0
 paths:
   /files/{file_id}:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -409,7 +409,7 @@ info:
   description: A service managing uploads of file objects to an S3-compatible Object
     Storage.
   title: Upload Controller Service
-  version: 2.1.0
+  version: 3.0.0
 openapi: 3.1.0
 paths:
   /files/{file_id}:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ucs"
-version = "2.0.0"
+version = "2.1.0"
 description = "The Upload-Controller Service (UCS) manages uploads to a S3 inbox bucket."
 dependencies = [
     "ghga-service-commons[all]>=2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ucs"
-version = "2.1.0"
+version = "3.0.0"
 description = "The Upload-Controller Service (UCS) manages uploads to a S3 inbox bucket."
 dependencies = [
     "ghga-service-commons[all]>=2.0.0",

--- a/src/ucs/adapters/inbound/event_sub.py
+++ b/src/ucs/adapters/inbound/event_sub.py
@@ -48,12 +48,12 @@ class EventSubTranslatorConfig(BaseSettings):
     )
 
     files_to_delete_topic: str = Field(
-        ...,
+        default=...,
         description="The name of the topic for events informing about files to be deleted.",
         examples=["file_deletions"],
     )
     files_to_delete_type: str = Field(
-        ...,
+        default=...,
         description="The type used for events informing about a file to be deleted.",
         examples=["file_deletion_requested"],
     )

--- a/src/ucs/adapters/inbound/event_sub.py
+++ b/src/ucs/adapters/inbound/event_sub.py
@@ -100,11 +100,13 @@ class EventSubTranslator(EventSubscriberProtocol):
     ):
         """Initialize with config parameters and core dependencies."""
         self.topics_of_interest = [
+            config.files_to_delete_topic,
             config.file_metadata_event_topic,
             config.upload_accepted_event_topic,
             config.upload_rejected_event_topic,
         ]
         self.types_of_interest = [
+            config.files_to_delete_type,
             config.file_metadata_event_type,
             config.upload_accepted_event_type,
             config.upload_rejected_event_type,

--- a/src/ucs/adapters/inbound/event_sub.py
+++ b/src/ucs/adapters/inbound/event_sub.py
@@ -156,7 +156,7 @@ class EventSubTranslator(EventSubscriberProtocol):
             payload=payload, schema=event_schemas.FileDeletionRequested
         )
 
-        await self._upload_service.delete_requested(file_id=validated_payload.file_id)
+        await self._upload_service.deletion_requested(file_id=validated_payload.file_id)
 
     async def _consume_validated(
         self,

--- a/src/ucs/adapters/outbound/event_pub.py
+++ b/src/ucs/adapters/outbound/event_pub.py
@@ -96,7 +96,7 @@ class EventPubTranslator(EventPublisherPort):
         )
 
     async def publish_deletion_successful(self, *, file_id: str) -> None:
-        """TODO"""
+        """Publish event informing that deletion of data and metadata for the given file ID has succeeded."""
         event_payload = event_schemas.FileDeletionSuccess(file_id=file_id)
 
         await self._provider.publish(

--- a/src/ucs/adapters/outbound/event_pub.py
+++ b/src/ucs/adapters/outbound/event_pub.py
@@ -27,16 +27,16 @@ from ucs.core import models
 from ucs.ports.outbound.event_pub import EventPublisherPort
 
 
-class EventPubTanslatorConfig(BaseSettings):
+class EventPubTranslatorConfig(BaseSettings):
     """Config for publishing file upload-related events."""
 
     file_deleted_event_topic: str = Field(
-        ...,
+        default=...,
         description="Name of the topic used for events indicating that a file has been deleted.",
         examples=["file_downloads"],
     )
     file_deleted_event_type: str = Field(
-        ...,
+        default=...,
         description="The type used for events indicating that a file has been deleted.",
         examples=["file_deleted"],
     )
@@ -60,7 +60,7 @@ class EventPubTranslator(EventPublisherPort):
     """
 
     def __init__(
-        self, *, config: EventPubTanslatorConfig, provider: EventPublisherProtocol
+        self, *, config: EventPubTranslatorConfig, provider: EventPublisherProtocol
     ):
         """Initialize with a suitable protocol provider."""
         self._config = config

--- a/src/ucs/adapters/outbound/event_pub.py
+++ b/src/ucs/adapters/outbound/event_pub.py
@@ -30,6 +30,17 @@ from ucs.ports.outbound.event_pub import EventPublisherPort
 class EventPubTanslatorConfig(BaseSettings):
     """Config for publishing file upload-related events."""
 
+    file_deleted_event_topic: str = Field(
+        ...,
+        description="Name of the topic used for events indicating that a file has been deleted.",
+        examples=["file_downloads"],
+    )
+    file_deleted_event_type: str = Field(
+        ...,
+        description="The type used for events indicating that a file has been deleted.",
+        examples=["file_deleted"],
+    )
+
     upload_received_event_topic: str = Field(
         default=...,
         description="Name of the topic to publish events that inform about new file "
@@ -82,4 +93,15 @@ class EventPubTranslator(EventPublisherPort):
             type_=self._config.upload_received_event_type,
             topic=self._config.upload_received_event_topic,
             key=file_metadata.file_id,
+        )
+
+    async def publish_deletion_successful(self, *, file_id: str) -> None:
+        """TODO"""
+        event_payload = event_schemas.FileDeletionSuccess(file_id=file_id)
+
+        await self._provider.publish(
+            payload=json.loads(event_payload.model_dump_json()),
+            type_=self._config.file_deleted_event_type,
+            topic=self._config.file_deleted_event_topic,
+            key=file_id,
         )

--- a/src/ucs/config.py
+++ b/src/ucs/config.py
@@ -23,18 +23,18 @@ from hexkit.providers.akafka import KafkaConfig
 from hexkit.providers.mongodb import MongoDbConfig
 
 from ucs.adapters.inbound.event_sub import EventSubTranslatorConfig
-from ucs.adapters.outbound.event_pub import EventPubTanslatorConfig
+from ucs.adapters.outbound.event_pub import EventPubTranslatorConfig
 
 
 @config_from_yaml(prefix="ucs")
-class Config(  # pylint: disable=too-many-ancestors
+class Config(
     ApiConfigBase,
     MongoDbConfig,
     S3ObjectStoragesConfig,
     KafkaConfig,
     LoggingConfig,
     EventSubTranslatorConfig,
-    EventPubTanslatorConfig,
+    EventPubTranslatorConfig,
 ):
     """Config parameters and their defaults."""
 

--- a/src/ucs/core/storage_inspector.py
+++ b/src/ucs/core/storage_inspector.py
@@ -1,0 +1,93 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Functionality to periodically deal with stale files in configured object storage."""
+
+import logging
+
+from ghga_service_commons.utils.multinode_storage import (
+    S3ObjectStorages,
+    S3ObjectStoragesConfig,
+)
+from hexkit.protocols.dao import MultipleHitsFoundError, NoHitsFoundError
+
+from ucs.core.models import UploadStatus
+from ucs.ports.inbound.storage_inspector import StorageInspectorPort
+from ucs.ports.inbound.upload_service import UploadServicePort
+from ucs.ports.outbound.dao import DaoCollectionPort
+
+log = logging.getLogger(__name__)
+
+
+class InboxInspector(StorageInspectorPort):
+    """Checks inbox storage buckets for stale files."""
+
+    def __init__(
+        self,
+        config: S3ObjectStoragesConfig,
+        daos: DaoCollectionPort,
+        object_storages: S3ObjectStorages,
+    ):
+        """Initialize with DB DAOs and storage handles."""
+        self._config = config
+        self._daos = daos
+        self._object_storages = object_storages
+
+    async def check_buckets(self):
+        """Check objects in all buckets configured for the service."""
+        for storage_alias in self._config.object_storages:
+            log.debug("Checking for stale objects in storage '%s'", storage_alias)
+
+            bucket_id, object_storage = self._object_storages.for_alias(
+                endpoint_alias=storage_alias
+            )
+            object_ids = await object_storage.list_all_object_ids(bucket_id=bucket_id)
+
+            for object_id in object_ids:
+                try:
+                    attempt = await self._daos.upload_attempts.find_one(
+                        mapping={"object_id": object_id}
+                    )
+                except (MultipleHitsFoundError, NoHitsFoundError) as error:
+                    # This service checks for inconsistencies elsewhere, so also check here
+                    out_of_sync = UploadServicePort.StorageAndDatabaseOutOfSyncError(
+                        problem=f"Unexpected amount of hits in database for object {object_id}"
+                        + f" in storage identified by alias {storage_alias}."
+                    )
+                    log.critical(
+                        out_of_sync,
+                        extra={"object_id": object_id, "storage_alias": storage_alias},
+                    )
+                    raise out_of_sync from error
+
+                # check if associated attempt status is one of the final statuses
+                if attempt.status in [
+                    UploadStatus.ACCEPTED,
+                    UploadStatus.CANCELLED,
+                    UploadStatus.FAILED,
+                    UploadStatus.REJECTED,
+                ]:
+                    extra = {
+                        "object_id": object_id,
+                        "file_id": attempt.file_id,
+                        "bucket_id": bucket_id,
+                        "storage_alias": storage_alias,
+                    }
+                    # only log for now, but this points to an underlying issue
+                    log.error(
+                        "Stale object '%s' found for file '%s' in bucket '%s' of storage '%s'.",
+                        *extra.values(),
+                        extra=extra,
+                    )

--- a/src/ucs/core/upload_service.py
+++ b/src/ucs/core/upload_service.py
@@ -209,7 +209,7 @@ class UploadService(UploadServicePort):
             )
             raise db_storage_not_synchronized from error
         finally:
-            # mark the upload as either accepted or rejected in the database:
+            # mark the upload as either accepted, rejected or failed in the database:
             updated_upload = latest_upload.model_copy(update={"status": final_status})
             await self._daos.upload_attempts.update(updated_upload)
 

--- a/src/ucs/core/upload_service.py
+++ b/src/ucs/core/upload_service.py
@@ -506,7 +506,7 @@ class UploadService(UploadServicePort):
             file_id=file_id, final_status=models.UploadStatus.REJECTED
         )
 
-    async def delete_requested(self, *, file_id: str) -> None:
+    async def deletion_requested(self, *, file_id: str) -> None:
         """
         Cancel the current upload attempt for the given file and remove all associated
         data related to upload attempts and file metadata.

--- a/src/ucs/main.py
+++ b/src/ucs/main.py
@@ -22,12 +22,14 @@ from ucs.config import Config
 from ucs.inject import (
     prepare_event_subscriber,
     prepare_rest_app,
+    prepare_storage_inspector,
 )
 
 
 async def run_rest_app():
     """Run the HTTP REST API."""
     config = Config()
+    configure_logging(config=config)
 
     async with prepare_rest_app(config=config) as app:
         await run_server(app=app, config=config)
@@ -40,3 +42,16 @@ async def consume_events(run_forever: bool = True):
 
     async with prepare_event_subscriber(config=config) as event_subscriber:
         await event_subscriber.run(forever=run_forever)
+
+
+async def check_inbox_buckets():
+    """Run a job to inspect all configured storage buckets for stale objects.
+
+    For now this only logs objects that should no longer remain in their respective bucket,
+    but have not been removed by the mechanisms in place.
+    """
+    config = Config()
+    configure_logging(config=config)
+
+    async with prepare_storage_inspector(config=config) as inbox_inspector:
+        await inbox_inspector.check_buckets()

--- a/src/ucs/ports/inbound/storage_inspector.py
+++ b/src/ucs/ports/inbound/storage_inspector.py
@@ -12,31 +12,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+"""Interfaces for periodic storage maintenance."""
 
-"""Entrypoint of the package"""
-
-import asyncio
-
-import typer
-
-from ucs.main import check_inbox_buckets, consume_events, run_rest_app
-
-cli = typer.Typer()
+from abc import ABC, abstractmethod
 
 
-@cli.command(name="run-rest")
-def sync_run_api():
-    """Run the HTTP REST API."""
-    asyncio.run(run_rest_app())
+class StorageInspectorPort(ABC):
+    """Interface for periodically checking storage buckets for stale files."""
 
-
-@cli.command(name="consume-events")
-def sync_consume_events(run_forever: bool = True):
-    """Run an event consumer listening to the specified topic."""
-    asyncio.run(consume_events(run_forever=run_forever))
-
-
-@cli.command(name="check-inbox-buckets")
-def sync_check_inbox_buckets():
-    """Run a job to check all objects no longer needed have been deleted"""
-    asyncio.run(check_inbox_buckets())
+    @abstractmethod
+    async def check_buckets(self):
+        """Check objects in all buckets configured for the service."""

--- a/src/ucs/ports/inbound/upload_service.py
+++ b/src/ucs/ports/inbound/upload_service.py
@@ -194,7 +194,7 @@ class UploadServicePort(ABC):
         ...
 
     @abstractmethod
-    async def delete_requested(self, *, file_id: str) -> None:
+    async def deletion_requested(self, *, file_id: str) -> None:
         """
         Cancel the current upload attempt for the given file and remove all associated
         data related to upload attempts and file metadata.

--- a/src/ucs/ports/inbound/upload_service.py
+++ b/src/ucs/ports/inbound/upload_service.py
@@ -192,3 +192,11 @@ class UploadServicePort(ABC):
         that only know the file ID not the upload attempt.
         """
         ...
+
+    @abstractmethod
+    async def delete_requested(self, *, file_id: str) -> None:
+        """
+        Cancel the current upload attempt for the given file and remove all associated
+        data related to upload attempts and file metadata.
+        """
+        ...

--- a/src/ucs/ports/outbound/event_pub.py
+++ b/src/ucs/ports/outbound/event_pub.py
@@ -36,3 +36,7 @@ class EventPublisherPort(Protocol):
     ) -> None:
         """Publish event informing that a new upload was received."""
         ...
+
+    async def publish_deletion_successful(self, *, file_id: str) -> None:
+        """TODO"""
+        ...

--- a/src/ucs/ports/outbound/event_pub.py
+++ b/src/ucs/ports/outbound/event_pub.py
@@ -38,5 +38,5 @@ class EventPublisherPort(Protocol):
         ...
 
     async def publish_deletion_successful(self, *, file_id: str) -> None:
-        """TODO"""
+        """Publish event informing that deletion of data and metadata for the given file ID has succeeded."""
         ...

--- a/tests/fixtures/joint.py
+++ b/tests/fixtures/joint.py
@@ -44,8 +44,14 @@ from tests.fixtures.config import get_config
 from tests.fixtures.example_data import STORAGE_ALIASES
 from ucs.adapters.outbound.dao import DaoCollectionTranslator
 from ucs.config import Config
-from ucs.inject import prepare_core, prepare_event_subscriber, prepare_rest_app
+from ucs.inject import (
+    prepare_core,
+    prepare_event_subscriber,
+    prepare_rest_app,
+    prepare_storage_inspector,
+)
 from ucs.ports.inbound.file_service import FileMetadataServicePort
+from ucs.ports.inbound.storage_inspector import StorageInspectorPort
 from ucs.ports.inbound.upload_service import UploadServicePort
 from ucs.ports.outbound.dao import DaoCollectionPort
 
@@ -64,6 +70,7 @@ class JointFixture:
     kafka: KafkaFixture
     s3: S3Fixture
     second_s3: S3Fixture
+    inbox_inspector: StorageInspectorPort
 
     async def reset_state(self):
         """Completely reset fixture states"""
@@ -108,7 +115,10 @@ async def joint_fixture_function(
     await second_s3_fixture.populate_buckets([bucket_id])
 
     # create a DI container instance:translators
-    async with prepare_core(config=config) as (upload_service, file_metadata_service):
+    async with prepare_core(config=config) as (
+        upload_service,
+        file_metadata_service,
+    ), prepare_storage_inspector(config=config) as inbox_inspector:
         async with (
             prepare_rest_app(
                 config=config, core_override=(upload_service, file_metadata_service)
@@ -129,6 +139,7 @@ async def joint_fixture_function(
                     kafka=kafka_fixture,
                     s3=s3_fixture,
                     second_s3=second_s3_fixture,
+                    inbox_inspector=inbox_inspector,
                 )
 
 

--- a/tests/fixtures/joint.py
+++ b/tests/fixtures/joint.py
@@ -70,6 +70,7 @@ class JointFixture:
     kafka: KafkaFixture
     s3: S3Fixture
     second_s3: S3Fixture
+    bucket_id: str
     inbox_inspector: StorageInspectorPort
 
     async def reset_state(self):
@@ -139,6 +140,7 @@ async def joint_fixture_function(
                     kafka=kafka_fixture,
                     s3=s3_fixture,
                     second_s3=second_s3_fixture,
+                    bucket_id=bucket_id,
                     inbox_inspector=inbox_inspector,
                 )
 

--- a/tests/fixtures/test_config.yaml
+++ b/tests/fixtures/test_config.yaml
@@ -7,6 +7,10 @@ object_storages:
       s3_endpoint_url: http://ucs:4566
       s3_access_key_id: test
       s3_secret_access_key: test
+files_to_delete_topic: file_deletions
+files_to_delete_type: file_deletion_requested
+file_deleted_event_topic: file_downloads
+file_deleted_event_type: file_deleted
 file_metadata_event_topic: metadata
 file_metadata_event_type: metadata_upsert
 upload_accepted_event_topic: internal_file_registry

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -19,11 +19,15 @@ Note: This test module uses the module-scoped fixtures.
 """
 
 import json
+from contextlib import suppress
 
 import pytest
 from fastapi import status
+from ghga_event_schemas import pydantic_ as event_schemas
+from hexkit.protocols.dao import ResourceNotFoundError
+from hexkit.providers.s3.testutils import upload_part_via_url
 
-from tests.fixtures.example_data import UPLOAD_DETAILS_1
+from tests.fixtures.example_data import UPLOAD_DETAILS_1, UPLOAD_DETAILS_2
 from tests.fixtures.module_scope_fixtures import (  # noqa: F401
     JointFixture,
     joint_fixture,
@@ -34,6 +38,52 @@ from tests.fixtures.module_scope_fixtures import (  # noqa: F401
     second_s3_fixture,
 )
 from ucs.core import models
+
+
+async def create_multipart_upload_with_data(
+    joint_fixture: JointFixture,  # noqa: F811
+    file_to_register: event_schemas.MetadataSubmissionFiles,
+    storage_alias: str,
+):
+    """Run upload process until first part is uploaded and status remains in pending."""
+    # publish event to register a new file for upload:
+    file_metadata_event = event_schemas.MetadataSubmissionUpserted(
+        associated_files=[file_to_register]
+    )
+    await joint_fixture.kafka.publish_event(
+        payload=file_metadata_event.model_dump(),
+        type_=joint_fixture.config.file_metadata_event_type,
+        topic=joint_fixture.config.file_metadata_event_topic,
+    )
+    # consume the event:
+    await joint_fixture.event_subscriber.run(forever=False)
+
+    file_id = file_to_register.file_id
+    # initiate new upload:
+    response = await joint_fixture.rest_client.post(
+        "/uploads",
+        json={
+            "file_id": file_id,
+            "submitter_public_key": "test-key",
+            "storage_alias": storage_alias,
+        },
+    )
+    assert response.status_code == status.HTTP_200_OK
+    upload_details = response.json()
+
+    # request an upload URL for a part:
+    response = await joint_fixture.rest_client.post(
+        f"/uploads/{upload_details['upload_id']}/parts/1/signed_urls"
+    )
+    assert response.status_code == status.HTTP_200_OK
+    part_upload_details = response.json()
+
+    # upload a file part with arbitrary content
+    upload_part_via_url(
+        url=part_upload_details["url"], size=upload_details["part_size"]
+    )
+
+    return upload_details["object_id"]
 
 
 @pytest.mark.asyncio(scope="module")
@@ -279,3 +329,79 @@ async def test_create_presigned_url_not_found(
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert response.json()["exception_id"] == "noSuchUpload"
+
+
+@pytest.mark.asyncio(scope="module")
+async def test_deletion_upload_ongoing(joint_fixture: JointFixture):  # noqa: F811
+    """Test file data deletion while upload is still ongoing.
+
+    This mainly tests if abort multipart upload worked correctly in the deletion context.
+    """
+    for s3, upload_details in zip(
+        (joint_fixture.s3, joint_fixture.second_s3),
+        (UPLOAD_DETAILS_1, UPLOAD_DETAILS_2),
+    ):
+        storage_alias = upload_details.storage_alias
+        file_to_register = upload_details.submission_metadata
+        file_id = file_to_register.file_id
+
+        inbox_object_id = await create_multipart_upload_with_data(
+            joint_fixture=joint_fixture,
+            file_to_register=file_to_register,
+            storage_alias=storage_alias,
+        )
+
+        # Verify everything that should exist is present
+        assert not await s3.storage.does_object_exist(
+            bucket_id=joint_fixture.bucket_id, object_id=inbox_object_id
+        )
+        with suppress(s3.storage.MultiPartUploadAlreadyExistsError):
+            await s3.storage._assert_no_multipart_upload(
+                bucket_id=joint_fixture.bucket_id, object_id=inbox_object_id
+            )
+        assert await joint_fixture.daos.file_metadata.get_by_id(id_=file_id)
+
+        num_attempts = 0
+        async for _ in joint_fixture.daos.upload_attempts.find_all(
+            mapping={"file_id": file_id}
+        ):
+            num_attempts += 1
+        assert num_attempts == 1
+
+        # Request deletion
+        deletion_event = event_schemas.FileDeletionRequested(file_id=file_id)
+        await joint_fixture.kafka.publish_event(
+            payload=json.loads(deletion_event.model_dump_json()),
+            type_=joint_fixture.config.files_to_delete_type,
+            topic=joint_fixture.config.files_to_delete_topic,
+        )
+
+        # Consume inbound event and check outbound event
+        deletion_successful_event = event_schemas.FileDeletionSuccess(file_id=file_id)
+        async with joint_fixture.kafka.record_events(
+            in_topic=joint_fixture.config.file_deleted_event_topic
+        ) as recorder:
+            await joint_fixture.event_subscriber.run(forever=False)
+
+        assert len(recorder.recorded_events) == 1
+        assert (
+            recorder.recorded_events[0].payload
+            == deletion_successful_event.model_dump()
+        )
+
+        # Verify everything is gone
+        assert not await s3.storage.does_object_exist(
+            bucket_id=joint_fixture.bucket_id, object_id=inbox_object_id
+        )
+        await s3.storage._assert_no_multipart_upload(
+            bucket_id=joint_fixture.bucket_id, object_id=inbox_object_id
+        )
+        with suppress(ResourceNotFoundError):
+            await joint_fixture.daos.file_metadata.get_by_id(id_=file_id)
+
+        num_attempts = 0
+        async for _ in joint_fixture.daos.upload_attempts.find_all(
+            mapping={"file_id": file_id}
+        ):
+            num_attempts += 1
+        assert num_attempts == 0

--- a/tests/test_typical_journey.py
+++ b/tests/test_typical_journey.py
@@ -21,12 +21,14 @@ service (incl. REST and event-driven APIs).
 
 import json
 import logging
+from contextlib import suppress
 from typing import Literal
 
 import pytest
 from fastapi import status
 from ghga_event_schemas import pydantic_ as event_schemas
 from ghga_service_commons.utils.utc_dates import now_as_utc
+from hexkit.protocols.dao import ResourceNotFoundError
 from hexkit.providers.s3.testutils import upload_part_via_url
 
 from tests.fixtures.example_data import UPLOAD_DETAILS_1, UPLOAD_DETAILS_2
@@ -53,10 +55,7 @@ async def run_until_uploaded(
     Run steps until uploaded data has been received and the upload attempt has been
     marked as uploaded
     """
-    # populate s3 storage:
-    # await joint_fixture.s3.populate_buckets([joint_fixture.config])
-
-    # publish event to register a new file for uplaod:
+    # publish event to register a new file for upload:
 
     file_metadata_event = event_schemas.MetadataSubmissionUpserted(
         associated_files=[file_to_register]
@@ -107,6 +106,8 @@ async def run_until_uploaded(
     payload = event_schemas.FileUploadReceived(**recorder.recorded_events[0].payload)
     assert payload.file_id == file_to_register.file_id
     assert payload.expected_decrypted_sha256 == file_to_register.decrypted_sha256
+
+    return payload.object_id
 
 
 async def perform_upload(
@@ -186,11 +187,14 @@ async def perform_upload(
 @pytest.mark.asyncio
 async def test_happy_journey(joint_fixture: JointFixture):  # noqa: F811
     """Test the typical anticipated/successful journey through the service's APIs."""
-    for upload_details in (UPLOAD_DETAILS_1, UPLOAD_DETAILS_2):
+    for s3, upload_details in zip(
+        (joint_fixture.s3, joint_fixture.second_s3),
+        (UPLOAD_DETAILS_1, UPLOAD_DETAILS_2),
+    ):
         storage_alias = upload_details.storage_alias
         file_to_register = upload_details.submission_metadata
 
-        await run_until_uploaded(
+        inbox_object_id = await run_until_uploaded(
             joint_fixture=joint_fixture,
             file_to_register=file_to_register,
             storage_alias=storage_alias,
@@ -222,17 +226,22 @@ async def test_happy_journey(joint_fixture: JointFixture):  # noqa: F811
 
         # make sure that the latest upload of the corresponding file was marked as
         # accepted:
-        # (first get the ID of the latest upload for that file:)
+        # First get the ID of the latest upload for that file
         response = await joint_fixture.rest_client.get(
             f"/files/{file_to_register.file_id}"
         )
         assert response.status_code == status.HTTP_200_OK
         latest_upload_id = response.json()["latest_upload_id"]
 
-        # (Then get details on that upload:)
+        # Then get upload details
         response = await joint_fixture.rest_client.get(f"/uploads/{latest_upload_id}")
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["status"] == "accepted"
+
+        # Finally verify the corresponding object has been removed from object storage
+        assert not await s3.storage.does_object_exist(
+            bucket_id=joint_fixture.bucket_id, object_id=inbox_object_id
+        )
 
 
 @pytest.mark.asyncio
@@ -242,11 +251,14 @@ async def test_unhappy_journey(joint_fixture: JointFixture):  # noqa: F811
     Work through the service's APIs, but reject the upload attempt due to a file
     validation error.
     """
-    for upload_details in (UPLOAD_DETAILS_1, UPLOAD_DETAILS_2):
+    for s3, upload_details in zip(
+        (joint_fixture.s3, joint_fixture.second_s3),
+        (UPLOAD_DETAILS_1, UPLOAD_DETAILS_2),
+    ):
         storage_alias = upload_details.storage_alias
         file_to_register = upload_details.submission_metadata
 
-        await run_until_uploaded(
+        inbox_object_id = await run_until_uploaded(
             joint_fixture=joint_fixture,
             file_to_register=file_to_register,
             storage_alias=storage_alias,
@@ -272,17 +284,22 @@ async def test_unhappy_journey(joint_fixture: JointFixture):  # noqa: F811
         await joint_fixture.event_subscriber.run(forever=False)
 
         # make sure that the latest upload of the corresponding file was marked as rejected:
-        # (first get the ID of the latest upload for that file:)
+        # First get the ID of the latest upload for that file
         response = await joint_fixture.rest_client.get(
             f"/files/{file_to_register.file_id}"
         )
         assert response.status_code == status.HTTP_200_OK
         latest_upload_id = response.json()["latest_upload_id"]
 
-        # (Then get details on that upload:)
+        # Then get upload details
         response = await joint_fixture.rest_client.get(f"/uploads/{latest_upload_id}")
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["status"] == "rejected"
+
+        # Finally verify the corresponding object has been removed from object storage
+        assert not await s3.storage.does_object_exist(
+            bucket_id=joint_fixture.bucket_id, object_id=inbox_object_id
+        )
 
 
 @pytest.mark.asyncio
@@ -291,25 +308,25 @@ async def test_inbox_inspector(
     joint_fixture: JointFixture,  # noqa: F811
 ):
     """Sanity check for inbox inspection functionality."""
-    # get configured bucket_id. To simplify things, it's the same for both storage aliases
-    bucket_id = next(iter(joint_fixture.config.object_storages.values())).bucket
-
+    # Run upload for both files and store object IDs
+    inbox_object_ids = []
     for upload_details in (UPLOAD_DETAILS_1, UPLOAD_DETAILS_2):
         storage_alias = upload_details.storage_alias
         file_to_register = upload_details.submission_metadata
 
-        await run_until_uploaded(
+        inbox_object_id = await run_until_uploaded(
             joint_fixture=joint_fixture,
             file_to_register=file_to_register,
             storage_alias=storage_alias,
         )
+        inbox_object_ids.append(inbox_object_id)
 
-    # this should remove the associated file
+    # Properly reject upload 1. This should remove the associated file
     failure_event = event_schemas.FileUploadValidationFailure(
         s3_endpoint_alias=UPLOAD_DETAILS_1.storage_alias,
         file_id=UPLOAD_DETAILS_1.submission_metadata.file_id,
         object_id=UPLOAD_DETAILS_1.upload_attempt.object_id,
-        bucket_id=bucket_id,
+        bucket_id=joint_fixture.bucket_id,
         upload_date=now_as_utc().isoformat(),
         reason="Sorry, but this has to fail.",
     )
@@ -318,6 +335,18 @@ async def test_inbox_inspector(
         payload=json.loads(failure_event.model_dump_json()),
         type_=joint_fixture.config.upload_rejected_event_type,
         topic=joint_fixture.config.upload_rejected_event_topic,
+    )
+
+    # make sure object is present before rejection and removed afterwards
+    properly_rejected_id = inbox_object_ids[0]
+    assert await joint_fixture.s3.storage.does_object_exist(
+        bucket_id=joint_fixture.bucket_id, object_id=properly_rejected_id
+    )
+
+    await joint_fixture.event_subscriber.run(forever=False)
+
+    assert not await joint_fixture.s3.storage.does_object_exist(
+        bucket_id=joint_fixture.bucket_id, object_id=properly_rejected_id
     )
 
     # Manipulate upload attempt to simulate stale file in need of removal
@@ -332,14 +361,89 @@ async def test_inbox_inspector(
     attempt.status = UploadStatus.REJECTED
     await joint_fixture.daos.upload_attempts.upsert(attempt)
 
+    # Verify ID matches and object is present to be properly logged as stale
+    stale_id = inbox_object_ids[1]
+    assert stale_id == attempt.object_id
+    assert await joint_fixture.second_s3.storage.does_object_exist(
+        bucket_id=joint_fixture.bucket_id, object_id=stale_id
+    )
+
     caplog.clear()
     caplog.set_level(level=logging.INFO, logger="ucs.core.storage_inspector")
 
     await joint_fixture.inbox_inspector.check_buckets()
     expected_message = (
-        f"Stale object '{attempt.object_id}' found for file '{attempt.file_id}' in bucket"
-        + f" '{bucket_id}' of storage '{attempt.storage_alias}'."
+        f"Stale object '{stale_id}' found for file '{attempt.file_id}' in bucket"
+        + f" '{joint_fixture.bucket_id}' of storage '{attempt.storage_alias}'."
     )
 
     assert len(caplog.messages) == 1
     assert expected_message in caplog.messages
+
+
+@pytest.mark.asyncio
+async def test_happy_deletion(joint_fixture: JointFixture):  # noqa: F811
+    """Test happy path for file data/metadata deletion, with file metadata, two upload attempts
+    and a file still in the inbox.
+    """
+    for s3, upload_details in zip(
+        (joint_fixture.s3, joint_fixture.second_s3),
+        (UPLOAD_DETAILS_1, UPLOAD_DETAILS_2),
+    ):
+        storage_alias = upload_details.storage_alias
+        file_to_register = upload_details.submission_metadata
+        file_id = upload_details.file_metadata.file_id
+
+        inbox_object_id = await run_until_uploaded(
+            joint_fixture=joint_fixture,
+            file_to_register=file_to_register,
+            storage_alias=storage_alias,
+        )
+
+        # Verify everything is present
+        assert await s3.storage.does_object_exist(
+            bucket_id=joint_fixture.bucket_id, object_id=inbox_object_id
+        )
+        assert await joint_fixture.daos.file_metadata.get_by_id(id_=file_id)
+
+        num_attempts = 0
+        async for _ in joint_fixture.daos.upload_attempts.find_all(
+            mapping={"file_id": file_id}
+        ):
+            num_attempts += 1
+        assert num_attempts == 2
+
+        # Request deletion
+        deletion_event = event_schemas.FileDeletionRequested(file_id=file_id)
+        await joint_fixture.kafka.publish_event(
+            payload=json.loads(deletion_event.model_dump_json()),
+            type_=joint_fixture.config.files_to_delete_type,
+            topic=joint_fixture.config.files_to_delete_topic,
+        )
+
+        # Consume inbound event and check outbound event
+        deletion_successful_event = event_schemas.FileDeletionSuccess(file_id=file_id)
+        async with joint_fixture.kafka.record_events(
+            in_topic=joint_fixture.config.file_deleted_event_topic
+        ) as recorder:
+            await joint_fixture.event_subscriber.run(forever=False)
+
+        assert len(recorder.recorded_events) == 1
+        assert (
+            recorder.recorded_events[0].payload
+            == deletion_successful_event.model_dump()
+        )
+
+        # Verify everything is gone
+        assert not await s3.storage.does_object_exist(
+            bucket_id=joint_fixture.bucket_id, object_id=inbox_object_id
+        )
+        with suppress(ResourceNotFoundError):
+            await joint_fixture.daos.file_metadata.get_by_id(id_=file_id)
+
+        num_attempts = 0
+        async for _ in joint_fixture.daos.upload_attempts.find_all(
+            mapping={"file_id": file_id}
+        ):
+            num_attempts += 1
+        assert num_attempts == 0


### PR DESCRIPTION
Added a new CLI command to run an `InboxInspector`, logging objects that are still in storage but should have been removed. This inspector iterates over all configured object storage/bucket pairs, fetches all current object IDs for those and checks if the current upload status is one of the final states and if so, logs the relevant information.

Added event subscriber path for file deletion requests from PCS.
This should remove associated file metadata, *all* upload attempts and transient data in the corresponding inbox bucket, both for ongoing and finished multipart uploads.

Added a rudimentary test case that covers existing deletion functionality and this new functionality.
Fixed an issue introduced in the last PR, where failed uploads still would not have their state set correctly to failed.
Bumped major version due to config changes.

